### PR TITLE
Add fine-planning and procurement parameter pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# ERP-System für einen Sondermaschinenbauer
+
+Dieses Repository enthält ein leichtgewichtiges ERP-Grundsystem, das auf die
+Prozesse eines Sondermaschinenbauers mit den Fertigungsverfahren Drehen,
+Fräsen, Laserschneiden, Kanten, Schweißen, Schleifen und Sägen zugeschnitten
+ist. Die Implementierung ist vollständig in Python gehalten und stellt
+Domänenmodelle, ein In-Memory-Datenmanagement sowie zentrale Services für
+Terminplanung, Materialwirtschaft und Rückmeldungen bereit.
+
+## Funktionsumfang
+
+- **Stammdatenverwaltung** für Kunden, Maschinenressourcen und Material.
+- **Fertigungsaufträge** mit mehrstufigen Operationen inkl. Rüst- und
+  Bearbeitungszeiten.
+- **Kapazitätsplanung** mit automatischer Zuordnung der Operationen zu den
+  passenden Maschinen und Ermittlung von Überlasten.
+- **Materialdisposition** mit Ermittlung von Bedarfen und Bestandslücken.
+- **Zeitdatenerfassung** zur Gegenüberstellung von Soll- und Ist-Zeiten.
+- **Persistente Speicherung** aller Stammdaten, Aufträge und Rückmeldungen in
+  einer SQLite-Datenbank.
+- **Feinplanung** über frei definierbare Schichtkalender mit Feiertags- und
+  Ausnahmeregeln sowie Priorisierung des Auftrags-Backlogs.
+- **Einkaufsintegration** mit Lieferantenbewertungen, automatischer
+  Bestellvorschlagserstellung und Lieferantenempfehlungen.
+- **Feinabstimmung der Planung** über konfigurierbare Parameter für
+  Prioritäten, Horizonte, Pufferzeiten und Beschaffungsstrategien.
+- **Simulation alternativer Planungsszenarien** zur Bewertung unterschiedlicher
+  Regelwerke und Startpunkte.
+- **Automatische Fertigungsunterlagen** mit prozessspezifischen Checklisten und
+  Arbeitsanweisungen für jede Operation.
+- **Rollenbasierte Benutzerverwaltung** für Administratoren, Planung, Einkauf
+  und Fertigung in der Weboberfläche.
+- **Weboberfläche** auf Basis von FastAPI und Jinja2 zur Bedienung der
+  wichtigsten ERP-Funktionen.
+
+## Projektstruktur
+
+```
+erp_system/
+├── __init__.py          # Paketexporte
+├── domain.py            # Domänenmodelle und Enums
+├── repository.py        # Generische In-Memory-Repositories
+├── services.py          # Service-Fassade inkl. Planung und Materialwirtschaft
+└── sample_usage.py      # Beispielskript für einen kompletten Ablauf
+```
+
+## Verwendung
+
+1. Python 3.11 oder höher installieren.
+2. Innerhalb des Repository-Verzeichnisses das Beispielskript ausführen:
+
+   ```bash
+   python -m erp_system.sample_usage
+   ```
+
+   Das Skript erzeugt Stammdaten, legt einen Produktionsauftrag an, plant die
+   Operationen und gibt Kapazitäts- sowie Materialberichte aus.
+
+3. Die Services lassen sich einfach in eigene Anwendungen integrieren, indem
+   eine Instanz von `ERPService` verwendet wird. Über die Methode
+   `build_operation` können individuelle Fertigungsschritte mit den geforderten
+   Fertigungsverfahren modelliert werden.
+
+## Weboberfläche starten
+
+1. Abhängigkeiten installieren:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Web-App mit uvicorn starten:
+
+   ```bash
+   uvicorn erp_system.web:create_app --reload
+   ```
+
+   Beim ersten Start werden automatisch Beispielstammdaten, Aufträge,
+   Lieferanten und Schichtkalender angelegt. Die Oberfläche bietet Zugriff auf
+   Dashboard, Feinplanung, Simulation, Einkauf, Lieferantenverwaltung,
+   Benutzeradministration und Schichtplanung. In der Feinplanung lassen sich
+   Prioritätsgewichte, Planungshorizont, Rüstzeitpuffer und automatische
+   Freigaben konfigurieren. Der Bereich Simulation erlaubt den Vergleich
+   alternativer Szenarien hinsichtlich Auslastung und Fertigstellung.
+   Zusätzlich stellt die Seite *Fertigungsunterlagen* automatisch generierte
+   Arbeitsanweisungen bereit, während die Benutzerverwaltung Rollen und
+   Aktivierungsstatus steuert. Der Bereich Einkauf ermöglicht die Anpassung des
+   Bestellmultiplikators, der Sicherheitsbestände sowie das direkte Auslösen von
+   Bestellungen aus Materialbedarfen.
+
+## Weiterentwicklungsideen
+
+- KI-gestützte Kapazitätsglättung mit automatischem Vorschlag alternativer
+  Schichtmodelle.
+- Integration von Qualitätsdaten und Prüfprotokollen in die
+  Fertigungsunterlagen.
+- Mobile Rückmeldungen und Andon-Anbindung für die Fertigungslinien.

--- a/erp_system/__init__.py
+++ b/erp_system/__init__.py
@@ -1,0 +1,62 @@
+"""Domain-specific ERP system for a special machine builder.
+
+This package provides data models, in-memory persistence, and scheduling
+services tailored to manufacturing processes like turning, milling, laser
+cutting, bending, welding, grinding, and sawing.
+"""
+
+from .domain import (
+    ChecklistItem,
+    ManufacturingProcess,
+    Customer,
+    Machine,
+    Operation,
+    OperationPlan,
+    ProductionOrder,
+    OrderStatus,
+    OrderPriority,
+    PlanningScenario,
+    PurchaseOrder,
+    Shift,
+    ShiftCalendar,
+    Supplier,
+    SupplierEvaluation,
+    User,
+    UserRole,
+    WorkInstruction,
+)
+from .services import (
+    ERPService,
+    MaterialShortage,
+    PlanningOptions,
+    ProcurementOptions,
+    ScheduleSummary,
+    ScenarioSimulationResult,
+)
+
+__all__ = [
+    "ChecklistItem",
+    "ManufacturingProcess",
+    "Customer",
+    "Machine",
+    "Operation",
+    "OperationPlan",
+    "ProductionOrder",
+    "OrderStatus",
+    "OrderPriority",
+    "PlanningScenario",
+    "PurchaseOrder",
+    "Shift",
+    "ShiftCalendar",
+    "Supplier",
+    "SupplierEvaluation",
+    "User",
+    "UserRole",
+    "WorkInstruction",
+    "ERPService",
+    "ScheduleSummary",
+    "ScenarioSimulationResult",
+    "MaterialShortage",
+    "PlanningOptions",
+    "ProcurementOptions",
+]

--- a/erp_system/domain.py
+++ b/erp_system/domain.py
@@ -1,0 +1,333 @@
+"""Core data structures for the special machine builder ERP system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, time
+from enum import Enum, IntEnum
+from typing import List, Optional, Sequence, Set, Tuple
+
+
+class ManufacturingProcess(str, Enum):
+    """Enumeration of the manufacturing processes used in the shop."""
+
+    TURNING = "Turning"
+    MILLING = "Milling"
+    LASER_CUTTING = "Laser Cutting"
+    BENDING = "Bending"
+    WELDING = "Welding"
+    GRINDING = "Grinding"
+    SAWING = "Sawing"
+
+
+class OrderStatus(str, Enum):
+    """Lifecycle stages for a production order."""
+
+    PLANNED = "Planned"
+    RELEASED = "Released"
+    IN_PROGRESS = "In Progress"
+    COMPLETED = "Completed"
+    CANCELLED = "Cancelled"
+
+
+class OrderPriority(IntEnum):
+    """Priority levels for production orders used during planning."""
+
+    LOW = 1
+    NORMAL = 2
+    HIGH = 3
+    CRITICAL = 4
+
+    @property
+    def label(self) -> str:
+        return {
+            OrderPriority.LOW: "Low",
+            OrderPriority.NORMAL: "Normal",
+            OrderPriority.HIGH: "High",
+            OrderPriority.CRITICAL: "Critical",
+        }[self]
+
+
+@dataclass(slots=True)
+class Customer:
+    """Customer master data."""
+
+    id: str
+    name: str
+    address: str
+    contact_person: str
+    contact_email: str = ""
+    contact_phone: str = ""
+    industry: str = ""
+
+
+@dataclass(slots=True)
+class Machine:
+    """A machine resource that can execute one or more processes."""
+
+    id: str
+    name: str
+    processes: Sequence[ManufacturingProcess]
+    capacity_hours_per_week: float
+    location: str = ""
+    manufacturer: str = ""
+    notes: str = ""
+    shift_calendar_id: Optional[str] = None
+
+
+@dataclass(slots=True)
+class InventoryItem:
+    """Simple material master for procurement and stock management."""
+
+    id: str
+    name: str
+    unit_of_measure: str
+    quantity_on_hand: float
+    safety_stock: float = 0.0
+    reorder_point: float = 0.0
+    lead_time_days: int = 0
+
+
+@dataclass(slots=True)
+class MaterialRequirement:
+    """A material requirement for a specific operation."""
+
+    item_id: str
+    quantity: float
+
+
+@dataclass(slots=True)
+class ChecklistItem:
+    """Single checklist entry for manufacturing preparation."""
+
+    description: str
+    mandatory: bool = True
+    reference: str = ""
+    completed: bool = False
+
+
+@dataclass(slots=True)
+class WorkInstruction:
+    """Aggregated instructions and checklist for an operation."""
+
+    order_id: str
+    order_reference: str
+    operation_id: str
+    operation_name: str
+    process: ManufacturingProcess
+    sequence: int
+    estimated_duration_hours: float
+    setup_time_hours: float
+    machine_id: Optional[str] = None
+    machine_name: str = ""
+    notes: str = ""
+    instructions: List[str] = field(default_factory=list)
+    checklist: List[ChecklistItem] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class Operation:
+    """An individual manufacturing step required for an order."""
+
+    id: str
+    name: str
+    process: ManufacturingProcess
+    duration_hours: float
+    setup_time_hours: float = 0.0
+    description: str = ""
+    materials: List[MaterialRequirement] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class OperationPlan:
+    """Scheduling metadata for a specific operation instance."""
+
+    operation: Operation
+    assigned_machine_id: Optional[str] = None
+    scheduled_start: Optional[datetime] = None
+    scheduled_end: Optional[datetime] = None
+    notes: str = ""
+
+
+@dataclass(slots=True)
+class ProductionOrder:
+    """Represents a confirmed order with a sequence of operations."""
+
+    id: str
+    customer_id: str
+    reference: str
+    due_date: date
+    status: OrderStatus = OrderStatus.PLANNED
+    priority: OrderPriority = OrderPriority.NORMAL
+    operations: List[OperationPlan] = field(default_factory=list)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    remarks: str = ""
+
+
+@dataclass(slots=True)
+class PurchaseOrder:
+    """Basic purchase order model for procuring external materials."""
+
+    id: str
+    supplier_id: str
+    item_id: str
+    quantity: float
+    expected_receipt: date
+    status: str = "Open"
+    supplier_name: str = ""
+    price_per_unit: float = 0.0
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    notes: str = ""
+
+
+@dataclass(slots=True)
+class TimeTrackingEntry:
+    """Actual production time feedback from the shop floor."""
+
+    id: str
+    order_id: str
+    operation_id: str
+    employee: str
+    start_time: datetime
+    end_time: datetime
+    remarks: str = ""
+
+
+@dataclass(slots=True)
+class Shift:
+    """Definition of a daily working shift."""
+
+    name: str
+    start_time: time
+    end_time: time
+    weekdays: Tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.weekdays:
+            raise ValueError("A shift must define at least one weekday")
+        for weekday in self.weekdays:
+            if weekday < 0 or weekday > 6:
+                raise ValueError("Weekday indices must be in range 0..6")
+        if self.end_time == self.start_time:
+            raise ValueError("Shift end time must differ from start time")
+
+
+@dataclass(slots=True)
+class ShiftCalendar:
+    """Collection of shifts and non-working days for capacity planning."""
+
+    id: str
+    name: str
+    shifts: List[Shift]
+    non_working_days: Set[date] = field(default_factory=set)
+
+    def add_non_working_day(self, day: date) -> None:
+        self.non_working_days.add(day)
+
+
+@dataclass(slots=True)
+class Supplier:
+    """Supplier master data including capability and rating information."""
+
+    id: str
+    name: str
+    address: str
+    contact_person: str = ""
+    contact_email: str = ""
+    contact_phone: str = ""
+    rating: float = 0.0
+    rating_count: int = 0
+    process_capabilities: Tuple[ManufacturingProcess, ...] = tuple()
+    material_item_ids: Tuple[str, ...] = tuple()
+
+
+@dataclass(slots=True)
+class SupplierEvaluation:
+    """Evaluation entry for a supplier performance review."""
+
+    id: str
+    supplier_id: str
+    evaluated_on: date
+    quality_score: float
+    delivery_reliability_score: float
+    communication_score: float
+    overall_score: float
+    notes: str = ""
+
+
+@dataclass(slots=True)
+class PlanningScenario:
+    """Definition of a what-if simulation for capacity planning."""
+
+    name: str
+    description: str = ""
+    priority_weight: Optional[float] = None
+    due_date_weight: Optional[float] = None
+    horizon_days: Optional[int] = None
+    max_orders_per_cycle: Optional[int] = None
+    auto_release_orders: Optional[bool] = None
+    default_start_time: Optional[time] = None
+    setup_time_factor: Optional[float] = None
+    gap_between_operations_minutes: Optional[int] = None
+    start_reference: Optional[datetime] = None
+    run_horizon_days: Optional[int] = None
+    run_max_orders: Optional[int] = None
+
+
+class UserRole(str, Enum):
+    """Supported roles for ERP web users."""
+
+    ADMIN = "admin"
+    PLANNER = "planner"
+    PURCHASER = "purchaser"
+    PRODUCTION = "production"
+    VIEWER = "viewer"
+
+    @property
+    def label(self) -> str:
+        return {
+            UserRole.ADMIN: "Administrator",
+            UserRole.PLANNER: "Planung",
+            UserRole.PURCHASER: "Einkauf",
+            UserRole.PRODUCTION: "Fertigung",
+            UserRole.VIEWER: "Leseberechtigt",
+        }[self]
+
+
+@dataclass(slots=True)
+class User:
+    """Representation of a web user with role assignments."""
+
+    id: str
+    username: str
+    full_name: str
+    email: str
+    roles: Tuple[UserRole, ...] = tuple()
+    is_active: bool = True
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    last_login: Optional[datetime] = None
+
+
+__all__ = [
+    "ChecklistItem",
+    "WorkInstruction",
+    "ManufacturingProcess",
+    "OrderStatus",
+    "OrderPriority",
+    "Customer",
+    "Machine",
+    "InventoryItem",
+    "MaterialRequirement",
+    "Operation",
+    "OperationPlan",
+    "ProductionOrder",
+    "PurchaseOrder",
+    "TimeTrackingEntry",
+    "Shift",
+    "ShiftCalendar",
+    "Supplier",
+    "SupplierEvaluation",
+    "PlanningScenario",
+    "UserRole",
+    "User",
+]

--- a/erp_system/repository.py
+++ b/erp_system/repository.py
@@ -1,0 +1,70 @@
+"""Simple in-memory repositories used by the ERP service layer."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Dict, Generic, Iterable, Iterator, List, MutableMapping, TypeVar
+
+T = TypeVar("T")
+
+
+class RepositoryError(RuntimeError):
+    """Base exception for repository errors."""
+
+
+class DuplicateRecordError(RepositoryError):
+    """Raised when attempting to insert a record that already exists."""
+
+
+class RecordNotFoundError(RepositoryError):
+    """Raised when a requested record is missing."""
+
+
+class InMemoryRepository(Generic[T]):
+    """Generic repository backed by a simple dictionary."""
+
+    def __init__(self) -> None:
+        self._items: MutableMapping[str, T] = {}
+
+    def __contains__(self, item_id: object) -> bool:  # pragma: no cover - convenience
+        return item_id in self._items
+
+    def __len__(self) -> int:  # pragma: no cover - convenience
+        return len(self._items)
+
+    def add(self, item_id: str, item: T) -> None:
+        if item_id in self._items:
+            raise DuplicateRecordError(f"Record with id {item_id!r} already exists")
+        self._items[item_id] = item
+
+    def upsert(self, item_id: str, item: T) -> None:
+        self._items[item_id] = item
+
+    def get(self, item_id: str) -> T:
+        try:
+            return self._items[item_id]
+        except KeyError as exc:  # pragma: no cover - trivial
+            raise RecordNotFoundError(f"Record with id {item_id!r} not found") from exc
+
+    def remove(self, item_id: str) -> None:
+        if item_id not in self._items:
+            raise RecordNotFoundError(f"Record with id {item_id!r} not found")
+        del self._items[item_id]
+
+    def list(self) -> List[T]:
+        return list(self._items.values())
+
+    def as_dicts(self) -> Iterable[Dict]:  # pragma: no cover - convenience
+        for item in self._items.values():
+            yield asdict(item)
+
+    def __iter__(self) -> Iterator[T]:  # pragma: no cover - convenience
+        return iter(self._items.values())
+
+
+__all__ = [
+    "InMemoryRepository",
+    "RepositoryError",
+    "DuplicateRecordError",
+    "RecordNotFoundError",
+]

--- a/erp_system/sample_usage.py
+++ b/erp_system/sample_usage.py
@@ -1,0 +1,442 @@
+"""Demonstration script for the special machine builder ERP system."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from pprint import pprint
+from typing import Dict
+
+from . import ERPService, ManufacturingProcess, OrderPriority, PlanningScenario, Shift, UserRole
+
+
+def main() -> None:
+    erp = ERPService()
+
+    day_shift = erp.create_shift_calendar(
+        name="Zwei-Schicht-System",
+        shifts=[
+            Shift(
+                name="Frühschicht",
+                start_time=time(6, 0),
+                end_time=time(14, 0),
+                weekdays=tuple(range(0, 5)),
+            ),
+            Shift(
+                name="Spätschicht",
+                start_time=time(14, 0),
+                end_time=time(22, 0),
+                weekdays=tuple(range(0, 5)),
+            ),
+        ],
+    )
+    erp.add_non_working_day(day_shift.id, date.today() + timedelta(days=7))
+
+    erp.update_planning_options(
+        priority_weight=1.1,
+        due_date_weight=0.9,
+        horizon_days=21,
+        max_orders_per_cycle=0,
+        auto_release_orders=True,
+        default_start_time=time(6, 0),
+        setup_time_factor=1.1,
+        gap_between_operations_minutes=15,
+    )
+    erp.update_procurement_options(
+        reorder_multiplier=1.1,
+        include_safety_stock_gap=True,
+        expedite_high_priority_days=2,
+        default_lead_time_days=3,
+        auto_create_orders=True,
+    )
+    print("Planungsparameter:", erp.planning_options)
+    print("Beschaffungsparameter:", erp.procurement_options)
+
+    # Stammdaten
+    customer = erp.create_customer(
+        name="Sondermaschinen Müller GmbH",
+        address="Werkstraße 12, 32547 Bad Oeynhausen",
+        contact_person="Sabine Hartmann",
+        contact_email="s.hartmann@sondermueller.de",
+        contact_phone="+49 5731 12345",
+        industry="Automotive",
+    )
+
+    turning_machine = erp.register_machine(
+        name="DMG MORI CTX beta 800",
+        processes=[ManufacturingProcess.TURNING],
+        capacity_hours_per_week=45,
+        location="Fertigungshalle A",
+        manufacturer="DMG MORI",
+        shift_calendar_id=day_shift.id,
+    )
+    milling_machine = erp.register_machine(
+        name="Hermle C 42 U",
+        processes=[ManufacturingProcess.MILLING],
+        capacity_hours_per_week=50,
+        location="Fertigungshalle A",
+        manufacturer="Hermle",
+        shift_calendar_id=day_shift.id,
+    )
+    laser_machine = erp.register_machine(
+        name="Trumpf TruLaser 3030",
+        processes=[ManufacturingProcess.LASER_CUTTING],
+        capacity_hours_per_week=60,
+        location="Blechzentrum",
+        manufacturer="Trumpf",
+        shift_calendar_id=day_shift.id,
+    )
+    bending_machine = erp.register_machine(
+        name="Trumpf TruBend 5230",
+        processes=[ManufacturingProcess.BENDING],
+        capacity_hours_per_week=40,
+        location="Blechzentrum",
+        manufacturer="Trumpf",
+        shift_calendar_id=day_shift.id,
+    )
+    welding_station = erp.register_machine(
+        name="Fronius TPSi 400",
+        processes=[ManufacturingProcess.WELDING],
+        capacity_hours_per_week=38,
+        location="Schweißerei",
+        manufacturer="Fronius",
+        shift_calendar_id=day_shift.id,
+    )
+    grinding_machine = erp.register_machine(
+        name="Jung J630",
+        processes=[ManufacturingProcess.GRINDING],
+        capacity_hours_per_week=32,
+        location="Finish-Bereich",
+        manufacturer="Jung",
+        shift_calendar_id=day_shift.id,
+    )
+    sawing_center = erp.register_machine(
+        name="Behringer HBP 413 A",
+        processes=[ManufacturingProcess.SAWING],
+        capacity_hours_per_week=28,
+        location="Sägezentrum",
+        manufacturer="Behringer",
+        shift_calendar_id=day_shift.id,
+    )
+
+    # Materialstamm
+    sheet_steel = erp.register_inventory_item(
+        name="Feinblech S355",
+        unit_of_measure="kg",
+        quantity_on_hand=180.0,
+        safety_stock=80.0,
+        reorder_point=100.0,
+        lead_time_days=5,
+    )
+    round_stock = erp.register_inventory_item(
+        name="Rundmaterial 42CrMo4",
+        unit_of_measure="kg",
+        quantity_on_hand=120.0,
+        safety_stock=60.0,
+        reorder_point=90.0,
+        lead_time_days=7,
+    )
+    welding_wire = erp.register_inventory_item(
+        name="Schweißdraht G3Si1",
+        unit_of_measure="kg",
+        quantity_on_hand=35.0,
+        safety_stock=20.0,
+        reorder_point=25.0,
+        lead_time_days=3,
+    )
+
+    steel_supplier = erp.register_supplier(
+        name="Stahlhandel Westfalen GmbH",
+        address="Industriestraße 5, 44147 Dortmund",
+        contact_person="Peter König",
+        contact_email="verkauf@stahlwestfalen.de",
+        contact_phone="+49 231 98765",
+        material_item_ids=[sheet_steel.id, round_stock.id],
+    )
+    erp.record_supplier_evaluation(
+        supplier_id=steel_supplier.id,
+        quality_score=4.5,
+        delivery_reliability_score=4.7,
+        communication_score=4.2,
+        notes="Sehr zuverlässige Lieferungen und faire Preise.",
+    )
+
+    welding_supplier = erp.register_supplier(
+        name="Schweißtechnik OWL",
+        address="Im Gewerbepark 7, 32760 Detmold",
+        contact_person="Anja Krüger",
+        contact_email="service@schweisstechnik-owl.de",
+        contact_phone="+49 5231 445566",
+        material_item_ids=[welding_wire.id],
+    )
+    erp.record_supplier_evaluation(
+        supplier_id=welding_supplier.id,
+        quality_score=4.8,
+        delivery_reliability_score=4.6,
+        communication_score=4.9,
+        notes="Gute Kommunikation und flexible Liefertermine.",
+    )
+
+    # Fertigungsablauf definieren
+    operations = [
+        erp.build_operation(
+            name="Zuschnitt sägen",
+            process=ManufacturingProcess.SAWING,
+            duration_hours=1.5,
+            setup_time_hours=0.25,
+            description="Rohmaterial auf Länge bringen",
+            materials=[(round_stock.id, 45.0)],
+        ),
+        erp.build_operation(
+            name="Drehen",
+            process=ManufacturingProcess.TURNING,
+            duration_hours=5.0,
+            setup_time_hours=0.5,
+            description="Alle Drehoperationen laut Zeichnung",
+        ),
+        erp.build_operation(
+            name="Fräsen",
+            process=ManufacturingProcess.MILLING,
+            duration_hours=4.0,
+            setup_time_hours=0.75,
+            description="Bearbeitung prismatischer Konturen",
+        ),
+        erp.build_operation(
+            name="Laserzuschnitt Blech",
+            process=ManufacturingProcess.LASER_CUTTING,
+            duration_hours=2.0,
+            setup_time_hours=0.25,
+            description="Laserschneiden von Blechkomponenten",
+            materials=[(sheet_steel.id, 60.0)],
+        ),
+        erp.build_operation(
+            name="Kanten",
+            process=ManufacturingProcess.BENDING,
+            duration_hours=1.0,
+            setup_time_hours=0.25,
+            description="Abkanten der Blechsegmente",
+        ),
+        erp.build_operation(
+            name="Schweißen",
+            process=ManufacturingProcess.WELDING,
+            duration_hours=3.5,
+            setup_time_hours=0.5,
+            description="Schweißen der Unterbaugruppen",
+            materials=[(welding_wire.id, 8.0)],
+        ),
+        erp.build_operation(
+            name="Schleifen",
+            process=ManufacturingProcess.GRINDING,
+            duration_hours=2.5,
+            setup_time_hours=0.25,
+            description="Finish der Funktionsflächen",
+        ),
+    ]
+
+    order = erp.create_production_order(
+        customer_id=customer.id,
+        reference="SO-2024-015",
+        due_date=date.today() + timedelta(days=14),
+        operations=operations,
+        remarks="Komplexer Maschinenträger mit hoher Maßhaltigkeit",
+        priority=OrderPriority.HIGH,
+    )
+
+    repeat_operations = [
+        erp.build_operation(
+            name="Rohling sägen",
+            process=ManufacturingProcess.SAWING,
+            duration_hours=1.0,
+            setup_time_hours=0.2,
+            description="Zuschnitt für Ersatzteilserie",
+            materials=[(round_stock.id, 20.0)],
+        ),
+        erp.build_operation(
+            name="Fräsen Kleinteil",
+            process=ManufacturingProcess.MILLING,
+            duration_hours=2.5,
+            setup_time_hours=0.5,
+            description="Bearbeitung prismatischer Aufnahmen",
+        ),
+        erp.build_operation(
+            name="Schweißen Unterbau",
+            process=ManufacturingProcess.WELDING,
+            duration_hours=1.0,
+            setup_time_hours=0.25,
+            description="Heften und Schweißen kleiner Baugruppe",
+            materials=[(welding_wire.id, 3.0)],
+        ),
+    ]
+
+    follow_up_order = erp.create_production_order(
+        customer_id=customer.id,
+        reference="SO-2024-016",
+        due_date=date.today() + timedelta(days=10),
+        operations=repeat_operations,
+        remarks="Ersatzteilserie für Bestandsmaschine",
+        priority=OrderPriority.NORMAL,
+    )
+
+    # Planung und Auswertung
+    backlog = dict(erp.schedule_backlog())
+    schedule = backlog[order.id]
+
+    print("Arbeitsplan")
+    for scheduled in schedule.scheduled_operations:
+        machine = erp.machines.get(scheduled.machine_id)
+        operation = next(
+            plan.operation
+            for plan in order.operations
+            if plan.operation.id == scheduled.operation_id
+        )
+        print(
+            f" - {operation.name} auf {machine.name}: {scheduled.start:%d.%m %H:%M}"
+            f" - {scheduled.end:%H:%M}"
+        )
+
+    print("\nKapazitätsauslastung")
+    combined_loads: Dict[str, float] = {}
+    combined_overloads: Dict[str, float] = {}
+    for summary in backlog.values():
+        combined_loads.update(summary.machine_loads)
+        combined_overloads.update(summary.overloaded_machines)
+    for machine_id, load in combined_loads.items():
+        machine = erp.machines.get(machine_id)
+        overload = combined_overloads.get(machine_id, 0.0)
+        message = f"   {machine.name}: {load:.2f}h von {machine.capacity_hours_per_week:.2f}h"
+        if overload > 0:
+            message += f"  -> Überlastung {overload:.2f}h"
+        print(message)
+
+    print("\nPriorisierte Aufträge")
+    for summary in backlog.values():
+        current_order = erp.orders.get(summary.order_id)
+        last_operation = max(
+            (plan for plan in current_order.operations if plan.scheduled_end),
+            key=lambda plan: plan.scheduled_end,
+        )
+        print(
+            f" - {current_order.reference} ({current_order.priority.label})"
+            f" -> Fertigstellung {last_operation.scheduled_end:%d.%m %H:%M}"
+        )
+
+    shortages = erp.material_shortage_report(order.id)
+    if shortages:
+        print("\nMaterialdisposition")
+        for shortage in shortages:
+            print(
+                f" - {shortage.name}: Bedarf {shortage.required_quantity:.1f} {shortage.projected_on_hand:+.1f} Bestandsprognose"
+            )
+            if shortage.reorder_recommendation > 0:
+                print(
+                    f"   Bestellung empfohlen: {shortage.reorder_recommendation:.1f} Einheiten"
+                )
+            if shortage.recommended_supplier_name:
+                print(
+                    f"   Empfohlener Lieferant: {shortage.recommended_supplier_name}"
+                )
+            else:
+                print("   Kein bewerteter Lieferant verfügbar")
+    else:
+        print("\nMaterialdisposition: Bestand ausreichend")
+
+    planned_orders = erp.plan_material_purchases(
+        order.id,
+        auto_create=True,
+        reorder_multiplier=1.05,
+        include_safety_stock=True,
+        expedite_high_priority_days=1,
+    )
+    if planned_orders:
+        print("\nEinkaufsplanung")
+        for purchase_order in planned_orders:
+            item = erp.inventory.get(purchase_order.item_id)
+            print(
+                f" - Bestellung {purchase_order.id[:8]}: {item.name} bei {purchase_order.supplier_name}"
+                f" ({purchase_order.quantity:.1f} {item.unit_of_measure}) bis {purchase_order.expected_receipt:%d.%m.%Y}"
+            )
+
+    print("\nLieferantenbewertungen")
+    for supplier in erp.suppliers:
+        print(
+            f" - {supplier.name}: {supplier.rating:.2f} Punkte aus {supplier.rating_count} Bewertung(en)"
+        )
+
+    upcoming = erp.get_upcoming_operations(limit=5)
+    print("\nNächste Operationen")
+    for entry in upcoming:
+        related_order = erp.orders.get(entry.order_id)
+        operation = next(
+            plan.operation
+            for plan in related_order.operations
+            if plan.operation.id == entry.operation_id
+        )
+        machine = erp.machines.get(entry.machine_id)
+        print(
+            f" - {operation.name} ({related_order.reference}, {related_order.priority.label})"
+            f" auf {machine.name} am {entry.start:%d.%m %H:%M}"
+        )
+
+    # Beispielhafte Rückmeldung von Ist-Zeiten
+    first_operation = order.operations[0].operation
+    erp.record_time_tracking(
+        order_id=order.id,
+        operation_id=first_operation.id,
+        employee="M. Schneider",
+        start_time=datetime.now(),
+        end_time=datetime.now() + timedelta(hours=1.75),
+        remarks="Zuschnitt lief störungsfrei",
+    )
+
+    variance = erp.calculate_actual_vs_plan(order.id)
+    print("\nSoll-/Ist-Vergleich")
+    pprint(variance)
+
+    documents = erp.generate_work_instructions(order.id)
+    print("\nFertigungsunterlagen")
+    for instruction in documents:
+        print(
+            f" - {instruction.sequence}. {instruction.operation_name} ({instruction.process.value})\n"
+            f"   Checkliste: {len(instruction.checklist)} Punkte, Maschine: {instruction.machine_name or instruction.machine_id or 'nicht zugewiesen'}"
+        )
+
+    scenarios = [
+        PlanningScenario(name="Aktuelle Einstellungen"),
+        PlanningScenario("Kurzfristig", run_horizon_days=7, run_max_orders=2),
+        PlanningScenario("Nachtschicht", default_start_time=time(22, 0), start_reference=datetime.now() + timedelta(days=1)),
+    ]
+    results = erp.simulate_planning_scenarios(scenarios)
+    print("\nSimulation alternativer Szenarien")
+    for result in results:
+        last_finish = (
+            max(result.completion_times.values()) if result.completion_times else None
+        )
+        print(
+            f" - {result.scenario.name}: {result.scheduled_orders} Aufträge, {result.total_operations} Operationen"
+            + (
+                f" (letzte Fertigstellung {last_finish:%d.%m.%Y %H:%M})"
+                if last_finish
+                else ""
+            )
+        )
+        for machine_id, overload in result.overloaded_machines.items():
+            print(f"   * Überlast auf {machine_id}: {overload:.2f} h")
+
+    planner_user = erp.create_user(
+        username="planerin",
+        full_name="Lena Planung",
+        email="lena.planung@example.com",
+        roles=[UserRole.PLANNER],
+    )
+    erp.assign_role_to_user(planner_user.id, UserRole.PURCHASER)
+    erp.record_user_login(planner_user.id)
+    print("\nBenutzerverwaltung")
+    for user in erp.users.list():
+        role_labels = ", ".join(role.label for role in user.roles) or "keine"
+        last_login = user.last_login.strftime("%d.%m.%Y %H:%M") if user.last_login else "keine Anmeldung"
+        print(
+            f" - {user.username} ({role_labels}) Status: {'aktiv' if user.is_active else 'inaktiv'}\n"
+            f"   Letzte Anmeldung: {last_login}"
+        )
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/erp_system/services.py
+++ b/erp_system/services.py
@@ -1,0 +1,1219 @@
+"""Service layer that implements core ERP logic."""
+
+from __future__ import annotations
+
+import copy
+
+from dataclasses import dataclass, field, replace
+from datetime import date, datetime, time, timedelta
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from uuid import uuid4
+
+from .domain import (
+    ChecklistItem,
+    Customer,
+    InventoryItem,
+    Machine,
+    ManufacturingProcess,
+    MaterialRequirement,
+    Operation,
+    OperationPlan,
+    OrderPriority,
+    OrderStatus,
+    PlanningScenario,
+    PurchaseOrder,
+    ProductionOrder,
+    Shift,
+    ShiftCalendar,
+    Supplier,
+    SupplierEvaluation,
+    TimeTrackingEntry,
+    User,
+    UserRole,
+    WorkInstruction,
+)
+from .repository import InMemoryRepository, RecordNotFoundError
+
+DEFAULT_SHIFT_START = time(6, 0)
+
+
+@dataclass(slots=True)
+class PlanningOptions:
+    """Fine-tuning parameters used by the scheduling engine."""
+
+    priority_weight: float = 1.0
+    due_date_weight: float = 1.0
+    horizon_days: int = 0
+    max_orders_per_cycle: int = 0
+    auto_release_orders: bool = True
+    default_start_time: time = field(default_factory=lambda: DEFAULT_SHIFT_START)
+    setup_time_factor: float = 1.0
+    gap_between_operations_minutes: int = 0
+
+
+@dataclass(slots=True)
+class ProcurementOptions:
+    """Configuration values controlling purchase planning."""
+
+    reorder_multiplier: float = 1.0
+    include_safety_stock_gap: bool = True
+    expedite_high_priority_days: int = 0
+    default_lead_time_days: int = 0
+    auto_create_orders: bool = False
+
+
+def _next_shift_window(
+    calendar: ShiftCalendar, reference: datetime
+) -> Optional[Tuple[datetime, datetime]]:
+    """Return the next usable shift window starting at or after reference."""
+
+    for day_offset in range(0, 60):
+        candidate_day = reference.date() + timedelta(days=day_offset)
+        if candidate_day in calendar.non_working_days:
+            continue
+        weekday = candidate_day.weekday()
+        matching = [
+            shift for shift in calendar.shifts if weekday in shift.weekdays
+        ]
+        if not matching:
+            continue
+        matching.sort(key=lambda shift: shift.start_time)
+        for shift in matching:
+            shift_start = datetime.combine(candidate_day, shift.start_time)
+            shift_end = datetime.combine(candidate_day, shift.end_time)
+            if shift_end <= shift_start:
+                shift_end += timedelta(days=1)
+            if shift_end <= reference:
+                continue
+            start_point = max(reference, shift_start)
+            return start_point, shift_end
+    return None
+
+
+def _allocate_with_calendar(
+    calendar: ShiftCalendar, reference: datetime, duration_hours: float
+) -> Tuple[datetime, datetime]:
+    """Find the next available slot respecting the configured shift calendar."""
+
+    remaining = timedelta(hours=duration_hours)
+    if remaining <= timedelta(0):
+        raise ValueError("Duration must be positive")
+    start_time: Optional[datetime] = None
+    cursor = reference
+
+    while remaining > timedelta(0):
+        window = _next_shift_window(calendar, cursor)
+        if window is None:
+            raise RuntimeError("No shift capacity available for scheduling")
+        window_start, window_end = window
+        cursor = max(cursor, window_start)
+        available = window_end - cursor
+        if available <= timedelta(0):
+            cursor = window_end + timedelta(minutes=1)
+            continue
+        if start_time is None:
+            start_time = cursor
+        allocation = min(available, remaining)
+        cursor += allocation
+        remaining -= allocation
+        if remaining <= timedelta(0):
+            return start_time, cursor
+        cursor = window_end + timedelta(minutes=1)
+    assert start_time is not None  # pragma: no cover - defensive
+    return start_time, cursor
+
+
+@dataclass(slots=True)
+class ScheduledOperation:
+    """Represents a single scheduled execution of an operation."""
+
+    order_id: str
+    operation_id: str
+    machine_id: str
+    start: datetime
+    end: datetime
+    exceeds_capacity: bool = False
+    order_priority: OrderPriority = OrderPriority.NORMAL
+
+
+@dataclass(slots=True)
+class MachineSchedule:
+    """Keeps track of bookings for a single machine."""
+
+    machine: Machine
+    calendar: Optional[ShiftCalendar]
+    next_available: datetime
+    total_allocated_hours: float = 0.0
+    operations: List[ScheduledOperation] = field(default_factory=list)
+
+    def allocate(
+        self,
+        order_id: str,
+        operation: Operation,
+        earliest_start: datetime,
+        priority: OrderPriority,
+        *,
+        setup_time_factor: float = 1.0,
+        gap_minutes: int = 0,
+    ) -> ScheduledOperation:
+        start_candidate = max(self.next_available, earliest_start)
+        setup_hours = max(operation.setup_time_hours * setup_time_factor, 0.0)
+        duration = operation.duration_hours + setup_hours
+        if duration <= 0:
+            raise ValueError("Operation duration must be positive")
+        if self.calendar is not None:
+            start_time, end_time = _allocate_with_calendar(
+                self.calendar, start_candidate, duration
+            )
+        else:
+            start_time = start_candidate
+            end_time = start_time + timedelta(hours=duration)
+        gap_delta = timedelta(minutes=gap_minutes) if gap_minutes > 0 else timedelta(0)
+        self.next_available = end_time + gap_delta
+        self.total_allocated_hours += duration
+        scheduled = ScheduledOperation(
+            order_id=order_id,
+            operation_id=operation.id,
+            machine_id=self.machine.id,
+            start=start_time,
+            end=end_time,
+            exceeds_capacity=self.total_allocated_hours > self.machine.capacity_hours_per_week,
+            order_priority=priority,
+        )
+        self.operations.append(scheduled)
+        return scheduled
+
+
+@dataclass(slots=True)
+class MaterialShortage:
+    """Summary of required purchasing action for a material."""
+
+    item_id: str
+    name: str
+    required_quantity: float
+    projected_on_hand: float
+    shortage: float
+    reorder_recommendation: float
+    recommended_supplier_id: Optional[str] = None
+    recommended_supplier_name: str = ""
+
+
+@dataclass(slots=True)
+class ScheduleSummary:
+    """Aggregate result returned after scheduling an order."""
+
+    order_id: str
+    scheduled_operations: List[ScheduledOperation]
+    machine_loads: Mapping[str, float]
+    overloaded_machines: Mapping[str, float]
+
+
+@dataclass(slots=True)
+class ScenarioSimulationResult:
+    """Aggregated metrics for a simulated planning scenario."""
+
+    scenario: PlanningScenario
+    options: PlanningOptions
+    summaries: Mapping[str, ScheduleSummary]
+    scheduled_orders: int
+    total_operations: int
+    machine_loads: Dict[str, float]
+    overloaded_machines: Dict[str, float]
+    completion_times: Dict[str, datetime]
+
+
+class ERPService:
+    """Facade that exposes ERP use-cases to clients."""
+
+    def __init__(
+        self,
+        customer_repo: Optional[InMemoryRepository[Customer]] = None,
+        machine_repo: Optional[InMemoryRepository[Machine]] = None,
+        order_repo: Optional[InMemoryRepository[ProductionOrder]] = None,
+        inventory_repo: Optional[InMemoryRepository[InventoryItem]] = None,
+        time_tracking_repo: Optional[InMemoryRepository[TimeTrackingEntry]] = None,
+        supplier_repo: Optional[InMemoryRepository[Supplier]] = None,
+        purchase_order_repo: Optional[InMemoryRepository[PurchaseOrder]] = None,
+        supplier_evaluation_repo: Optional[
+            InMemoryRepository[SupplierEvaluation]
+        ] = None,
+        shift_calendar_repo: Optional[InMemoryRepository[ShiftCalendar]] = None,
+        user_repo: Optional[InMemoryRepository[User]] = None,
+    ) -> None:
+        self.customers = customer_repo or InMemoryRepository()
+        self.machines = machine_repo or InMemoryRepository()
+        self.orders = order_repo or InMemoryRepository()
+        self.inventory = inventory_repo or InMemoryRepository()
+        self.time_tracking = time_tracking_repo or InMemoryRepository()
+        self.suppliers = supplier_repo or InMemoryRepository()
+        self.purchase_orders = purchase_order_repo or InMemoryRepository()
+        self.supplier_evaluations = (
+            supplier_evaluation_repo or InMemoryRepository()
+        )
+        self.shift_calendars = shift_calendar_repo or InMemoryRepository()
+        self.users = user_repo or InMemoryRepository()
+        self._machine_schedules: Dict[str, MachineSchedule] = {}
+        self.planning_options = PlanningOptions()
+        self.procurement_options = ProcurementOptions()
+
+    # ------------------------------------------------------------------
+    # Master data
+    # ------------------------------------------------------------------
+    def create_customer(
+        self,
+        name: str,
+        address: str,
+        contact_person: str,
+        *,
+        contact_email: str = "",
+        contact_phone: str = "",
+        industry: str = "",
+    ) -> Customer:
+        customer = Customer(
+            id=str(uuid4()),
+            name=name,
+            address=address,
+            contact_person=contact_person,
+            contact_email=contact_email,
+            contact_phone=contact_phone,
+            industry=industry,
+        )
+        self.customers.add(customer.id, customer)
+        return customer
+
+    def register_machine(
+        self,
+        name: str,
+        processes: Sequence[ManufacturingProcess],
+        *,
+        capacity_hours_per_week: float,
+        location: str = "",
+        manufacturer: str = "",
+        notes: str = "",
+        shift_calendar_id: Optional[str] = None,
+    ) -> Machine:
+        if not processes:
+            raise ValueError("A machine must support at least one manufacturing process")
+        if shift_calendar_id is not None and shift_calendar_id not in self.shift_calendars:
+            raise RecordNotFoundError(
+                f"Shift calendar {shift_calendar_id!r} does not exist"
+            )
+        machine = Machine(
+            id=str(uuid4()),
+            name=name,
+            processes=tuple(dict.fromkeys(processes)),
+            capacity_hours_per_week=capacity_hours_per_week,
+            location=location,
+            manufacturer=manufacturer,
+            notes=notes,
+            shift_calendar_id=shift_calendar_id,
+        )
+        self.machines.add(machine.id, machine)
+        return machine
+
+    def register_inventory_item(
+        self,
+        name: str,
+        unit_of_measure: str,
+        *,
+        quantity_on_hand: float,
+        safety_stock: float = 0.0,
+        reorder_point: float = 0.0,
+        lead_time_days: int = 0,
+    ) -> InventoryItem:
+        item = InventoryItem(
+            id=str(uuid4()),
+            name=name,
+            unit_of_measure=unit_of_measure,
+            quantity_on_hand=quantity_on_hand,
+            safety_stock=safety_stock,
+            reorder_point=reorder_point,
+            lead_time_days=lead_time_days,
+        )
+        self.inventory.add(item.id, item)
+        return item
+
+    # ------------------------------------------------------------------
+    # Shift calendar management
+    # ------------------------------------------------------------------
+    def create_shift_calendar(
+        self,
+        name: str,
+        shifts: Sequence[Shift],
+        *,
+        non_working_days: Optional[Sequence[date]] = None,
+    ) -> ShiftCalendar:
+        if not shifts:
+            raise ValueError("A shift calendar must contain at least one shift")
+        calendar = ShiftCalendar(
+            id=str(uuid4()),
+            name=name,
+            shifts=list(shifts),
+            non_working_days=set(non_working_days or ()),
+        )
+        self.shift_calendars.add(calendar.id, calendar)
+        return calendar
+
+    def assign_shift_calendar(self, machine_id: str, calendar_id: str) -> Machine:
+        machine = self.machines.get(machine_id)
+        calendar = self.shift_calendars.get(calendar_id)
+        machine.shift_calendar_id = calendar.id
+        self.machines.upsert(machine.id, machine)
+        schedule = self._machine_schedules.get(machine_id)
+        if schedule is not None:
+            schedule.calendar = calendar
+        return machine
+
+    def add_non_working_day(self, calendar_id: str, day: date) -> ShiftCalendar:
+        calendar = self.shift_calendars.get(calendar_id)
+        calendar.non_working_days.add(day)
+        self.shift_calendars.upsert(calendar.id, calendar)
+        for schedule in self._machine_schedules.values():
+            if schedule.machine.shift_calendar_id == calendar_id:
+                schedule.calendar = calendar
+        return calendar
+
+    # ------------------------------------------------------------------
+    # User management
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_roles(roles: Sequence[UserRole]) -> Tuple[UserRole, ...]:
+        unique: List[UserRole] = []
+        for role in roles:
+            if role not in unique:
+                unique.append(role)
+        return tuple(unique)
+
+    def create_user(
+        self,
+        username: str,
+        full_name: str,
+        email: str,
+        *,
+        roles: Optional[Sequence[UserRole]] = None,
+        is_active: bool = True,
+    ) -> User:
+        user = User(
+            id=str(uuid4()),
+            username=username,
+            full_name=full_name,
+            email=email,
+            roles=self._normalize_roles(roles or ()),
+            is_active=is_active,
+        )
+        self.users.add(user.id, user)
+        return user
+
+    def update_user_roles(self, user_id: str, roles: Sequence[UserRole]) -> User:
+        user = self.users.get(user_id)
+        user.roles = self._normalize_roles(roles)
+        self.users.upsert(user.id, user)
+        return user
+
+    def assign_role_to_user(self, user_id: str, role: UserRole) -> User:
+        user = self.users.get(user_id)
+        if role not in user.roles:
+            user.roles = tuple((*user.roles, role))
+            self.users.upsert(user.id, user)
+        return user
+
+    def remove_role_from_user(self, user_id: str, role: UserRole) -> User:
+        user = self.users.get(user_id)
+        if role in user.roles:
+            user.roles = tuple(r for r in user.roles if r != role)
+            self.users.upsert(user.id, user)
+        return user
+
+    def set_user_active(self, user_id: str, active: bool) -> User:
+        user = self.users.get(user_id)
+        user.is_active = active
+        self.users.upsert(user.id, user)
+        return user
+
+    def list_users_by_role(self, role: Optional[UserRole] = None) -> List[User]:
+        users = self.users.list()
+        users.sort(key=lambda entry: entry.full_name.lower() or entry.username.lower())
+        if role is None:
+            return users
+        return [user for user in users if role in user.roles]
+
+    def record_user_login(self, user_id: str) -> User:
+        user = self.users.get(user_id)
+        user.last_login = datetime.utcnow()
+        self.users.upsert(user.id, user)
+        return user
+
+    # ------------------------------------------------------------------
+    # Supplier management and purchasing
+    # ------------------------------------------------------------------
+    def register_supplier(
+        self,
+        name: str,
+        address: str,
+        *,
+        contact_person: str = "",
+        contact_email: str = "",
+        contact_phone: str = "",
+        process_capabilities: Optional[Sequence[ManufacturingProcess]] = None,
+        material_item_ids: Optional[Sequence[str]] = None,
+    ) -> Supplier:
+        supplier = Supplier(
+            id=str(uuid4()),
+            name=name,
+            address=address,
+            contact_person=contact_person,
+            contact_email=contact_email,
+            contact_phone=contact_phone,
+            process_capabilities=tuple(dict.fromkeys(process_capabilities or ())),
+            material_item_ids=tuple(dict.fromkeys(material_item_ids or ())),
+        )
+        self.suppliers.add(supplier.id, supplier)
+        return supplier
+
+    def link_supplier_to_material(self, supplier_id: str, item_id: str) -> Supplier:
+        supplier = self.suppliers.get(supplier_id)
+        if item_id not in self.inventory:
+            raise RecordNotFoundError(f"Inventory item {item_id!r} not found")
+        if item_id in supplier.material_item_ids:
+            return supplier
+        supplier.material_item_ids = tuple((*supplier.material_item_ids, item_id))
+        self.suppliers.upsert(supplier.id, supplier)
+        return supplier
+
+    def record_supplier_evaluation(
+        self,
+        supplier_id: str,
+        quality_score: float,
+        delivery_reliability_score: float,
+        communication_score: float,
+        *,
+        evaluated_on: Optional[date] = None,
+        notes: str = "",
+    ) -> SupplierEvaluation:
+        supplier = self.suppliers.get(supplier_id)
+        evaluated_on = evaluated_on or date.today()
+        overall = (
+            quality_score + delivery_reliability_score + communication_score
+        ) / 3.0
+        evaluation = SupplierEvaluation(
+            id=str(uuid4()),
+            supplier_id=supplier_id,
+            evaluated_on=evaluated_on,
+            quality_score=quality_score,
+            delivery_reliability_score=delivery_reliability_score,
+            communication_score=communication_score,
+            overall_score=overall,
+            notes=notes,
+        )
+        self.supplier_evaluations.add(evaluation.id, evaluation)
+        total = supplier.rating * supplier.rating_count + overall
+        supplier.rating_count += 1
+        supplier.rating = total / float(supplier.rating_count)
+        self.suppliers.upsert(supplier.id, supplier)
+        return evaluation
+
+    def recommend_supplier_for_item(self, item_id: str) -> Optional[Supplier]:
+        candidates = [
+            supplier
+            for supplier in self.suppliers
+            if item_id in supplier.material_item_ids
+        ]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda supplier: supplier.rating, reverse=True)
+        return candidates[0]
+
+    # ------------------------------------------------------------------
+    # Production orders
+    # ------------------------------------------------------------------
+    @staticmethod
+    def build_operation(
+        name: str,
+        process: ManufacturingProcess,
+        *,
+        duration_hours: float,
+        setup_time_hours: float = 0.0,
+        description: str = "",
+        materials: Optional[Iterable[Tuple[str, float]]] = None,
+    ) -> Operation:
+        material_requirements = [
+            MaterialRequirement(item_id=item_id, quantity=quantity)
+            for item_id, quantity in (materials or [])
+        ]
+        return Operation(
+            id=str(uuid4()),
+            name=name,
+            process=process,
+            duration_hours=duration_hours,
+            setup_time_hours=setup_time_hours,
+            description=description,
+            materials=material_requirements,
+        )
+
+    def create_production_order(
+        self,
+        customer_id: str,
+        reference: str,
+        due_date: date,
+        operations: Sequence[Operation],
+        *,
+        remarks: str = "",
+        priority: OrderPriority = OrderPriority.NORMAL,
+    ) -> ProductionOrder:
+        if customer_id not in self.customers:
+            raise RecordNotFoundError(f"Customer {customer_id!r} does not exist")
+        if not operations:
+            raise ValueError("Production orders must contain at least one operation")
+        order = ProductionOrder(
+            id=str(uuid4()),
+            customer_id=customer_id,
+            reference=reference,
+            due_date=due_date,
+            priority=priority,
+            operations=[OperationPlan(operation=operation) for operation in operations],
+            remarks=remarks,
+        )
+        self.orders.add(order.id, order)
+        return order
+
+    def add_operation_to_order(self, order_id: str, operation: Operation) -> ProductionOrder:
+        order = self.orders.get(order_id)
+        order.operations.append(OperationPlan(operation=operation))
+        self.orders.upsert(order.id, order)
+        return order
+
+    def update_order_status(self, order_id: str, status: OrderStatus) -> ProductionOrder:
+        order = self.orders.get(order_id)
+        order.status = status
+        self.orders.upsert(order.id, order)
+        return order
+
+    # ------------------------------------------------------------------
+    # Scheduling
+    # ------------------------------------------------------------------
+    def reset_machine_schedules(self) -> None:
+        """Clear cached machine schedules to rebuild planning from scratch."""
+
+        self._machine_schedules.clear()
+
+    def update_planning_options(
+        self,
+        *,
+        priority_weight: float,
+        due_date_weight: float,
+        horizon_days: int,
+        max_orders_per_cycle: int,
+        auto_release_orders: bool,
+        default_start_time: time,
+        setup_time_factor: float,
+        gap_between_operations_minutes: int,
+    ) -> PlanningOptions:
+        """Apply new fine-tuning parameters for scheduling."""
+
+        self.planning_options = PlanningOptions(
+            priority_weight=max(priority_weight, 0.01),
+            due_date_weight=max(due_date_weight, 0.0),
+            horizon_days=max(horizon_days, 0),
+            max_orders_per_cycle=max(max_orders_per_cycle, 0),
+            auto_release_orders=auto_release_orders,
+            default_start_time=default_start_time,
+            setup_time_factor=max(setup_time_factor, 0.0),
+            gap_between_operations_minutes=max(gap_between_operations_minutes, 0),
+        )
+        self.reset_machine_schedules()
+        return self.planning_options
+
+    def update_procurement_options(
+        self,
+        *,
+        reorder_multiplier: float,
+        include_safety_stock_gap: bool,
+        expedite_high_priority_days: int,
+        default_lead_time_days: int,
+        auto_create_orders: bool,
+    ) -> ProcurementOptions:
+        """Persist procurement configuration."""
+
+        self.procurement_options = ProcurementOptions(
+            reorder_multiplier=max(reorder_multiplier, 0.0),
+            include_safety_stock_gap=include_safety_stock_gap,
+            expedite_high_priority_days=max(expedite_high_priority_days, 0),
+            default_lead_time_days=max(default_lead_time_days, 0),
+            auto_create_orders=auto_create_orders,
+        )
+        return self.procurement_options
+
+    def _clone_for_simulation(self) -> "ERPService":
+        """Create an isolated copy of the service state for simulations."""
+
+        clone = ERPService()
+        clone.planning_options = copy.deepcopy(self.planning_options)
+        clone.procurement_options = copy.deepcopy(self.procurement_options)
+        for repo_name in (
+            "customers",
+            "machines",
+            "orders",
+            "inventory",
+            "time_tracking",
+            "suppliers",
+            "purchase_orders",
+            "supplier_evaluations",
+            "shift_calendars",
+            "users",
+        ):
+            source = getattr(self, repo_name)
+            target = getattr(clone, repo_name)
+            for item in source.list():
+                item_id = getattr(item, "id", None)
+                if item_id is None:
+                    continue
+                target.add(item_id, copy.deepcopy(item))
+        return clone
+
+    def _eligible_machines(self, process: ManufacturingProcess) -> List[Machine]:
+        machines = [machine for machine in self.machines if process in machine.processes]
+        if not machines:
+            raise RecordNotFoundError(
+                f"No machines configured for process {process.value}"
+            )
+        return machines
+
+    def _get_machine_schedule(self, machine_id: str, start_reference: datetime) -> MachineSchedule:
+        schedule = self._machine_schedules.get(machine_id)
+        if schedule is None:
+            machine = self.machines.get(machine_id)
+            calendar = None
+            if machine.shift_calendar_id:
+                try:
+                    calendar = self.shift_calendars.get(machine.shift_calendar_id)
+                except RecordNotFoundError:
+                    calendar = None
+            schedule = MachineSchedule(
+                machine=machine,
+                calendar=calendar,
+                next_available=start_reference,
+            )
+            self._machine_schedules[machine_id] = schedule
+        return schedule
+
+    def schedule_operations(
+        self,
+        order_id: str,
+        *,
+        start_reference: Optional[datetime] = None,
+    ) -> ScheduleSummary:
+        order = self.orders.get(order_id)
+        options = self.planning_options
+        default_start = options.default_start_time or DEFAULT_SHIFT_START
+        start_reference = start_reference or datetime.combine(date.today(), default_start)
+        earliest_start = start_reference
+        setup_factor = max(options.setup_time_factor, 0.0)
+        gap_minutes = max(options.gap_between_operations_minutes, 0)
+        gap_delta = timedelta(minutes=gap_minutes) if gap_minutes > 0 else timedelta(0)
+        scheduled_operations: List[ScheduledOperation] = []
+        used_machine_ids: List[str] = []
+
+        for plan in order.operations:
+            machines = self._eligible_machines(plan.operation.process)
+            candidate_schedules = [
+                self._get_machine_schedule(machine.id, start_reference) for machine in machines
+            ]
+            candidate_schedules.sort(key=lambda schedule: schedule.total_allocated_hours)
+            schedule = candidate_schedules[0]
+            scheduled = schedule.allocate(
+                order.id,
+                plan.operation,
+                earliest_start,
+                order.priority,
+                setup_time_factor=setup_factor,
+                gap_minutes=gap_minutes,
+            )
+            plan.assigned_machine_id = scheduled.machine_id
+            plan.scheduled_start = scheduled.start
+            plan.scheduled_end = scheduled.end
+            scheduled_operations.append(scheduled)
+            used_machine_ids.append(schedule.machine.id)
+            earliest_start = scheduled.end + gap_delta
+
+        self.orders.upsert(order.id, order)
+        if options.auto_release_orders and order.status == OrderStatus.PLANNED:
+            order.status = OrderStatus.RELEASED
+            self.orders.upsert(order.id, order)
+
+        machine_loads = {
+            machine_id: self._machine_schedules[machine_id].total_allocated_hours
+            for machine_id in used_machine_ids
+        }
+        overloaded = {
+            machine_id: max(
+                0.0,
+                self._machine_schedules[machine_id].total_allocated_hours
+                - self._machine_schedules[machine_id].machine.capacity_hours_per_week,
+            )
+            for machine_id in used_machine_ids
+            if self._machine_schedules[machine_id].total_allocated_hours
+            > self._machine_schedules[machine_id].machine.capacity_hours_per_week
+        }
+
+        return ScheduleSummary(
+            order_id=order.id,
+            scheduled_operations=scheduled_operations,
+            machine_loads=machine_loads,
+            overloaded_machines=overloaded,
+        )
+
+    def schedule_backlog(
+        self,
+        *,
+        start_reference: Optional[datetime] = None,
+        horizon_days: Optional[int] = None,
+        max_orders: Optional[int] = None,
+    ) -> Mapping[str, ScheduleSummary]:
+        """Schedule all open orders using the configured planning options."""
+
+        self.reset_machine_schedules()
+        options = self.planning_options
+        default_start = options.default_start_time or DEFAULT_SHIFT_START
+        start_reference = start_reference or datetime.combine(
+            date.today(), default_start
+        )
+        horizon = (
+            options.horizon_days if horizon_days is None else max(horizon_days, 0)
+        )
+        limit = (
+            options.max_orders_per_cycle
+            if max_orders is None
+            else max(max_orders, 0)
+        )
+        priority_weight = max(options.priority_weight, 0.01)
+        due_weight = max(options.due_date_weight, 0.0)
+        backlog_orders = [
+            order
+            for order in self.orders
+            if order.status not in {OrderStatus.COMPLETED, OrderStatus.CANCELLED}
+        ]
+        if horizon > 0:
+            horizon_date = date.today() + timedelta(days=horizon)
+            backlog_orders = [
+                order
+                for order in backlog_orders
+                if order.due_date <= horizon_date
+                or order.priority >= OrderPriority.HIGH
+            ]
+
+        def backlog_key(order: ProductionOrder) -> Tuple[float, float, datetime]:
+            priority_score = -int(order.priority) * priority_weight
+            due_date_score = order.due_date.toordinal() * due_weight
+            return (priority_score, due_date_score, order.created_at)
+
+        backlog_orders.sort(key=backlog_key)
+        if limit > 0:
+            backlog_orders = backlog_orders[:limit]
+        summaries: Dict[str, ScheduleSummary] = {}
+        for order in backlog_orders:
+            summaries[order.id] = self.schedule_operations(
+                order.id, start_reference=start_reference
+            )
+        return summaries
+
+    def simulate_planning_scenarios(
+        self, scenarios: Sequence[PlanningScenario]
+    ) -> List[ScenarioSimulationResult]:
+        """Run what-if simulations for alternative planning parameters."""
+
+        if not scenarios:
+            return []
+        results: List[ScenarioSimulationResult] = []
+        base_options = self.planning_options
+        for scenario in scenarios:
+            clone = self._clone_for_simulation()
+            override_kwargs: Dict[str, object] = {}
+            if scenario.priority_weight is not None:
+                override_kwargs["priority_weight"] = max(scenario.priority_weight, 0.01)
+            if scenario.due_date_weight is not None:
+                override_kwargs["due_date_weight"] = max(scenario.due_date_weight, 0.0)
+            if scenario.horizon_days is not None:
+                override_kwargs["horizon_days"] = max(scenario.horizon_days, 0)
+            if scenario.max_orders_per_cycle is not None:
+                override_kwargs["max_orders_per_cycle"] = max(scenario.max_orders_per_cycle, 0)
+            if scenario.auto_release_orders is not None:
+                override_kwargs["auto_release_orders"] = scenario.auto_release_orders
+            if scenario.default_start_time is not None:
+                override_kwargs["default_start_time"] = scenario.default_start_time
+            if scenario.setup_time_factor is not None:
+                override_kwargs["setup_time_factor"] = max(scenario.setup_time_factor, 0.0)
+            if scenario.gap_between_operations_minutes is not None:
+                override_kwargs["gap_between_operations_minutes"] = max(
+                    scenario.gap_between_operations_minutes, 0
+                )
+            if override_kwargs:
+                clone.planning_options = replace(base_options, **override_kwargs)
+            else:
+                clone.planning_options = copy.deepcopy(base_options)
+            horizon_arg = scenario.run_horizon_days
+            max_orders_arg = scenario.run_max_orders
+            summaries = dict(
+                clone.schedule_backlog(
+                    start_reference=scenario.start_reference,
+                    horizon_days=horizon_arg,
+                    max_orders=max_orders_arg,
+                )
+            )
+            machine_loads: Dict[str, float] = {}
+            overloaded: Dict[str, float] = {}
+            completion_times: Dict[str, datetime] = {}
+            for summary in summaries.values():
+                for machine_id, load in summary.machine_loads.items():
+                    machine_loads[machine_id] = machine_loads.get(machine_id, 0.0) + load
+                for machine_id, overload in summary.overloaded_machines.items():
+                    overloaded[machine_id] = overloaded.get(machine_id, 0.0) + overload
+                if summary.scheduled_operations:
+                    completion_times[summary.order_id] = max(
+                        operation.end for operation in summary.scheduled_operations
+                    )
+            result = ScenarioSimulationResult(
+                scenario=scenario,
+                options=clone.planning_options,
+                summaries=summaries,
+                scheduled_orders=len(summaries),
+                total_operations=sum(
+                    len(summary.scheduled_operations) for summary in summaries.values()
+                ),
+                machine_loads=machine_loads,
+                overloaded_machines=overloaded,
+                completion_times=completion_times,
+            )
+            results.append(result)
+        return results
+
+    def get_upcoming_operations(self, *, limit: int = 10) -> List[ScheduledOperation]:
+        """Return upcoming scheduled operations ordered by start time."""
+
+        operations: List[ScheduledOperation] = []
+        for order in self.orders:
+            for plan in order.operations:
+                if (
+                    plan.scheduled_start is not None
+                    and plan.scheduled_end is not None
+                    and plan.assigned_machine_id is not None
+                ):
+                    operations.append(
+                        ScheduledOperation(
+                            order_id=order.id,
+                            operation_id=plan.operation.id,
+                            machine_id=plan.assigned_machine_id,
+                            start=plan.scheduled_start,
+                            end=plan.scheduled_end,
+                            exceeds_capacity=False,
+                            order_priority=order.priority,
+                        )
+                    )
+        operations.sort(key=lambda op: op.start)
+        return operations[:limit] if limit else operations
+
+    def generate_work_instructions(self, order_id: str) -> List[WorkInstruction]:
+        """Create structured work instructions and checklists for an order."""
+
+        order = self.orders.get(order_id)
+        instructions: List[WorkInstruction] = []
+        process_hints = {
+            ManufacturingProcess.TURNING: "Werkzeugverschleiß prüfen und Kühlmittelstand kontrollieren.",
+            ManufacturingProcess.MILLING: "Nullpunkt und Spannmittel gemäß Aufspannungsvorgabe prüfen.",
+            ManufacturingProcess.LASER_CUTTING: "Brennerdüse reinigen und Schneidgasdruck kontrollieren.",
+            ManufacturingProcess.BENDING: "Biegewinkel anhand Musterteil verifizieren.",
+            ManufacturingProcess.WELDING: "WPS beachten und Nahtfolge dokumentieren.",
+            ManufacturingProcess.GRINDING: "Schleifscheibe abrichten und Kühlschmierstoffzufuhr prüfen.",
+            ManufacturingProcess.SAWING: "Sägebandzustand prüfen und Spannstock sichern.",
+        }
+        for index, plan in enumerate(order.operations, start=1):
+            machine_name = "Nicht zugeordnet"
+            if plan.assigned_machine_id:
+                try:
+                    machine = self.machines.get(plan.assigned_machine_id)
+                    machine_name = machine.name
+                except RecordNotFoundError:
+                    machine_name = plan.assigned_machine_id
+            detail_lines: List[str] = []
+            if plan.operation.description:
+                detail_lines.append(plan.operation.description)
+            detail_lines.append(f"Prozess: {plan.operation.process.value}")
+            detail_lines.append(f"Bearbeitungszeit: {plan.operation.duration_hours:.2f} h")
+            if plan.operation.setup_time_hours:
+                detail_lines.append(f"Rüstzeit: {plan.operation.setup_time_hours:.2f} h")
+            hint = process_hints.get(plan.operation.process)
+            if hint:
+                detail_lines.append(hint)
+            if plan.scheduled_start and plan.scheduled_end:
+                detail_lines.append(
+                    f"Geplanter Ablauf: {plan.scheduled_start:%d.%m.%Y %H:%M} – {plan.scheduled_end:%H:%M}"
+                )
+            checklist: List[ChecklistItem] = []
+            for requirement in plan.operation.materials:
+                try:
+                    item = self.inventory.get(requirement.item_id)
+                    item_name = item.name
+                    unit = item.unit_of_measure
+                except RecordNotFoundError:
+                    item_name = requirement.item_id
+                    unit = "Einheiten"
+                checklist.append(
+                    ChecklistItem(
+                        description=(
+                            f"Material {item_name} bereitstellen ({requirement.quantity:.2f} {unit})"
+                        ),
+                        reference=item_name,
+                    )
+                )
+            checklist.append(
+                ChecklistItem(
+                    description="Persönliche Schutzausrüstung prüfen",
+                    reference="PSA",
+                )
+            )
+            if plan.operation.process == ManufacturingProcess.WELDING:
+                checklist.append(
+                    ChecklistItem(
+                        description="Schweißzusatz freigeben und Nahtprüfung dokumentieren",
+                        reference="QS-Weld",
+                        mandatory=False,
+                    )
+                )
+            if plan.operation.process == ManufacturingProcess.GRINDING:
+                checklist.append(
+                    ChecklistItem(
+                        description="Oberflächenrauheit messen und Ergebnis eintragen",
+                        reference="QM",
+                    )
+                )
+            checklist.append(
+                ChecklistItem(
+                    description="Arbeitsplatz reinigen und Freigabe dokumentieren",
+                    reference="5S",
+                    mandatory=False,
+                )
+            )
+            instructions.append(
+                WorkInstruction(
+                    order_id=order.id,
+                    order_reference=order.reference,
+                    operation_id=plan.operation.id,
+                    operation_name=plan.operation.name,
+                    process=plan.operation.process,
+                    sequence=index,
+                    estimated_duration_hours=plan.operation.duration_hours,
+                    setup_time_hours=plan.operation.setup_time_hours,
+                    machine_id=plan.assigned_machine_id,
+                    machine_name=machine_name,
+                    notes=plan.notes or order.remarks,
+                    instructions=detail_lines,
+                    checklist=checklist,
+                )
+            )
+        return instructions
+
+    # ------------------------------------------------------------------
+    # Material management
+    # ------------------------------------------------------------------
+    def material_shortage_report(
+        self,
+        order_id: str,
+        *,
+        include_safety_stock: Optional[bool] = None,
+        reorder_multiplier: Optional[float] = None,
+    ) -> List[MaterialShortage]:
+        order = self.orders.get(order_id)
+        aggregated_requirements: Dict[str, float] = {}
+        for plan in order.operations:
+            for requirement in plan.operation.materials:
+                aggregated_requirements[requirement.item_id] = aggregated_requirements.get(
+                    requirement.item_id, 0.0
+                ) + requirement.quantity
+
+        shortages: List[MaterialShortage] = []
+        options = self.procurement_options
+        include_safety = (
+            options.include_safety_stock_gap
+            if include_safety_stock is None
+            else include_safety_stock
+        )
+        multiplier = (
+            options.reorder_multiplier
+            if reorder_multiplier is None
+            else reorder_multiplier
+        )
+        multiplier = max(multiplier, 0.0)
+        for item_id, required_quantity in aggregated_requirements.items():
+            try:
+                item = self.inventory.get(item_id)
+            except RecordNotFoundError:
+                shortages.append(
+                    MaterialShortage(
+                        item_id=item_id,
+                        name="Unbekannte Position",
+                        required_quantity=required_quantity,
+                        projected_on_hand=-required_quantity,
+                        shortage=required_quantity,
+                        reorder_recommendation=required_quantity,
+                    )
+                )
+                continue
+
+            projected_on_hand = item.quantity_on_hand - required_quantity
+            safety_gap = item.safety_stock - projected_on_hand if include_safety else 0.0
+            shortage = max(0.0, safety_gap)
+            reorder_trigger = item.reorder_point - projected_on_hand
+            reorder_recommendation = max(shortage, reorder_trigger, 0.0) * multiplier
+            if shortage > 0 or projected_on_hand < item.reorder_point:
+                supplier = self.recommend_supplier_for_item(item.id)
+                shortages.append(
+                    MaterialShortage(
+                        item_id=item.id,
+                        name=item.name,
+                        required_quantity=required_quantity,
+                        projected_on_hand=projected_on_hand,
+                        shortage=shortage,
+                        reorder_recommendation=reorder_recommendation,
+                        recommended_supplier_id=supplier.id if supplier else None,
+                        recommended_supplier_name=supplier.name if supplier else "",
+                    )
+                )
+        return shortages
+
+    def plan_material_purchases(
+        self,
+        order_id: str,
+        *,
+        auto_create: Optional[bool] = None,
+        reorder_multiplier: Optional[float] = None,
+        include_safety_stock: Optional[bool] = None,
+        expedite_high_priority_days: Optional[int] = None,
+    ) -> List[PurchaseOrder]:
+        order = self.orders.get(order_id)
+        options = self.procurement_options
+        auto_create_flag = (
+            options.auto_create_orders if auto_create is None else auto_create
+        )
+        multiplier = (
+            options.reorder_multiplier
+            if reorder_multiplier is None
+            else reorder_multiplier
+        )
+        multiplier = max(multiplier, 0.0)
+        include_safety = (
+            options.include_safety_stock_gap
+            if include_safety_stock is None
+            else include_safety_stock
+        )
+        expedite_days = (
+            options.expedite_high_priority_days
+            if expedite_high_priority_days is None
+            else max(expedite_high_priority_days, 0)
+        )
+        default_lead_time = max(options.default_lead_time_days, 0)
+        shortages = self.material_shortage_report(
+            order_id,
+            include_safety_stock=include_safety,
+            reorder_multiplier=multiplier,
+        )
+        planned: List[PurchaseOrder] = []
+        for shortage in shortages:
+            if shortage.reorder_recommendation <= 0 and shortage.shortage <= 0:
+                continue
+            try:
+                item = self.inventory.get(shortage.item_id)
+            except RecordNotFoundError:
+                continue
+            supplier = None
+            if shortage.recommended_supplier_id:
+                try:
+                    supplier = self.suppliers.get(shortage.recommended_supplier_id)
+                except RecordNotFoundError:
+                    supplier = None
+            if supplier is None:
+                supplier = self.recommend_supplier_for_item(item.id)
+            if supplier is None:
+                continue
+            quantity = max(shortage.reorder_recommendation, shortage.shortage)
+            base_lead_time = item.lead_time_days or default_lead_time
+            base_lead_time = max(base_lead_time, 1)
+            if order.priority >= OrderPriority.HIGH and expedite_days > 0:
+                base_lead_time = max(1, base_lead_time - expedite_days)
+            expected_receipt = date.today() + timedelta(days=base_lead_time)
+            purchase_order = PurchaseOrder(
+                id=str(uuid4()),
+                supplier_id=supplier.id,
+                supplier_name=supplier.name,
+                item_id=item.id,
+                quantity=quantity,
+                expected_receipt=expected_receipt,
+                status="Open" if auto_create_flag else "Planned",
+                notes=f"Automatisch geplant für Auftrag {order.reference}",
+            )
+            if auto_create_flag:
+                self.purchase_orders.add(purchase_order.id, purchase_order)
+            planned.append(purchase_order)
+        return planned
+
+    def consume_materials(self, order_id: str) -> None:
+        order = self.orders.get(order_id)
+        for plan in order.operations:
+            for requirement in plan.operation.materials:
+                try:
+                    item = self.inventory.get(requirement.item_id)
+                except RecordNotFoundError as exc:
+                    raise RecordNotFoundError(
+                        f"Material {requirement.item_id!r} is not present in inventory"
+                    ) from exc
+                item.quantity_on_hand -= requirement.quantity
+                self.inventory.upsert(item.id, item)
+
+    # ------------------------------------------------------------------
+    # Time tracking
+    # ------------------------------------------------------------------
+    def record_time_tracking(
+        self,
+        order_id: str,
+        operation_id: str,
+        employee: str,
+        *,
+        start_time: datetime,
+        end_time: datetime,
+        remarks: str = "",
+    ) -> TimeTrackingEntry:
+        entry = TimeTrackingEntry(
+            id=str(uuid4()),
+            order_id=order_id,
+            operation_id=operation_id,
+            employee=employee,
+            start_time=start_time,
+            end_time=end_time,
+            remarks=remarks,
+        )
+        self.time_tracking.add(entry.id, entry)
+        return entry
+
+    def calculate_actual_vs_plan(self, order_id: str) -> Dict[str, float]:
+        """Compare planned vs. actual hours for the given order."""
+
+        order = self.orders.get(order_id)
+        planned_hours = sum(
+            plan.operation.duration_hours + plan.operation.setup_time_hours
+            for plan in order.operations
+        )
+        actual_hours = 0.0
+        for entry in self.time_tracking:
+            if entry.order_id == order_id:
+                delta = entry.end_time - entry.start_time
+                actual_hours += delta.total_seconds() / 3600
+        return {"planned_hours": planned_hours, "actual_hours": actual_hours}
+
+
+__all__ = [
+    "ERPService",
+    "ScheduleSummary",
+    "ScheduledOperation",
+    "ScenarioSimulationResult",
+    "MaterialShortage",
+    "PlanningOptions",
+    "ProcurementOptions",
+]

--- a/erp_system/storage.py
+++ b/erp_system/storage.py
@@ -1,0 +1,143 @@
+"""SQLite-backed persistence helpers for the ERP system."""
+
+from __future__ import annotations
+
+import pickle
+import sqlite3
+from typing import Generic, Iterator, List, Optional, TypeVar
+
+from .domain import (
+    Customer,
+    InventoryItem,
+    Machine,
+    ProductionOrder,
+    PurchaseOrder,
+    ShiftCalendar,
+    Supplier,
+    SupplierEvaluation,
+    TimeTrackingEntry,
+    User,
+)
+from .repository import DuplicateRecordError, RecordNotFoundError
+
+T = TypeVar("T")
+
+
+class SQLiteRepository(Generic[T]):
+    """Repository implementation that persists records inside SQLite."""
+
+    def __init__(self, connection: sqlite3.Connection, table: str) -> None:
+        self._connection = connection
+        self._table = table
+        self._connection.execute(
+            f"CREATE TABLE IF NOT EXISTS {table} ("  # nosec - static table names
+            "id TEXT PRIMARY KEY, payload BLOB NOT NULL)"
+        )
+        self._connection.commit()
+
+    def __contains__(self, item_id: object) -> bool:
+        if not isinstance(item_id, str):  # pragma: no cover - defensive
+            return False
+        cursor = self._connection.execute(
+            f"SELECT 1 FROM {self._table} WHERE id = ? LIMIT 1", (item_id,)
+        )
+        return cursor.fetchone() is not None
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self.list())
+
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
+        cursor = self._connection.execute(
+            f"SELECT COUNT(1) FROM {self._table}"
+        )
+        value = cursor.fetchone()
+        return int(value[0]) if value else 0
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def add(self, item_id: str, item: T) -> None:
+        if item_id in self:
+            raise DuplicateRecordError(f"Record with id {item_id!r} already exists")
+        payload = pickle.dumps(item)
+        self._connection.execute(
+            f"INSERT INTO {self._table} (id, payload) VALUES (?, ?)",
+            (item_id, payload),
+        )
+        self._connection.commit()
+
+    def upsert(self, item_id: str, item: T) -> None:
+        payload = pickle.dumps(item)
+        self._connection.execute(
+            f"INSERT INTO {self._table} (id, payload) VALUES (?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET payload = excluded.payload",
+            (item_id, payload),
+        )
+        self._connection.commit()
+
+    def get(self, item_id: str) -> T:
+        cursor = self._connection.execute(
+            f"SELECT payload FROM {self._table} WHERE id = ?", (item_id,)
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise RecordNotFoundError(f"Record with id {item_id!r} not found")
+        return pickle.loads(row[0])
+
+    def remove(self, item_id: str) -> None:
+        cursor = self._connection.execute(
+            f"DELETE FROM {self._table} WHERE id = ?", (item_id,)
+        )
+        if cursor.rowcount == 0:
+            raise RecordNotFoundError(f"Record with id {item_id!r} not found")
+        self._connection.commit()
+
+    def list(self) -> List[T]:
+        cursor = self._connection.execute(
+            f"SELECT payload FROM {self._table} ORDER BY id"
+        )
+        return [pickle.loads(row[0]) for row in cursor.fetchall()]
+
+
+class ERPDatabase:
+    """Convenience facade bundling SQLite repositories for all aggregates."""
+
+    def __init__(self, path: str) -> None:
+        connection = sqlite3.connect(path, check_same_thread=False)
+        connection.row_factory = sqlite3.Row
+        self._connection = connection
+        self.customers = SQLiteRepository[Customer](connection, "customers")
+        self.machines = SQLiteRepository[Machine](connection, "machines")
+        self.orders = SQLiteRepository[ProductionOrder](connection, "orders")
+        self.inventory = SQLiteRepository[InventoryItem](connection, "inventory")
+        self.time_tracking = SQLiteRepository[TimeTrackingEntry](connection, "time_tracking")
+        self.suppliers = SQLiteRepository[Supplier](connection, "suppliers")
+        self.purchase_orders = SQLiteRepository[PurchaseOrder](connection, "purchase_orders")
+        self.supplier_evaluations = SQLiteRepository[SupplierEvaluation](
+            connection, "supplier_evaluations"
+        )
+        self.shift_calendars = SQLiteRepository[ShiftCalendar](
+            connection, "shift_calendars"
+        )
+        self.users = SQLiteRepository[User](connection, "users")
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._connection
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def __enter__(self) -> "ERPDatabase":  # pragma: no cover - convenience
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        traceback: Optional[BaseException],
+    ) -> None:  # pragma: no cover - convenience
+        self.close()
+
+
+__all__ = ["SQLiteRepository", "ERPDatabase"]

--- a/erp_system/web/__init__.py
+++ b/erp_system/web/__init__.py
@@ -1,0 +1,5 @@
+"""Web interface for the special machine builder ERP system."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/erp_system/web/app.py
+++ b/erp_system/web/app.py
@@ -1,0 +1,1071 @@
+"""FastAPI-based web interface for the ERP system."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence
+from urllib.parse import urlencode
+
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from ..domain import (
+    ManufacturingProcess,
+    OrderPriority,
+    OrderStatus,
+    PlanningScenario,
+    Shift,
+    UserRole,
+)
+from ..repository import RecordNotFoundError
+from ..services import ERPService
+from ..storage import ERPDatabase
+
+TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+
+def create_app(database_path: str = "erp.sqlite3") -> FastAPI:
+    database = ERPDatabase(database_path)
+    service = ERPService(
+        customer_repo=database.customers,
+        machine_repo=database.machines,
+        order_repo=database.orders,
+        inventory_repo=database.inventory,
+        time_tracking_repo=database.time_tracking,
+        supplier_repo=database.suppliers,
+        purchase_order_repo=database.purchase_orders,
+        supplier_evaluation_repo=database.supplier_evaluations,
+        shift_calendar_repo=database.shift_calendars,
+        user_repo=database.users,
+    )
+    ensure_demo_data(service)
+
+    app = FastAPI(title="Sondermaschinenbau ERP")
+    app.state.erp_service = service
+    app.state.database = database
+
+    @app.on_event("shutdown")
+    async def shutdown_event() -> None:  # pragma: no cover - framework hook
+        database.close()
+
+    @app.get("/")
+    async def dashboard(request: Request):
+        service: ERPService = request.app.state.erp_service
+        orders = sorted(
+            service.orders.list(),
+            key=lambda order: (order.due_date, -int(order.priority)),
+        )
+        customers = service.customers.list()
+        machines = service.machines.list()
+        calendars = service.shift_calendars.list()
+        inventory = service.inventory.list()
+        purchase_orders = sorted(
+            service.purchase_orders.list(), key=lambda po: po.expected_receipt
+        )
+        suppliers = service.suppliers.list()
+        shortages = []
+        for order in orders:
+            if order.status in {OrderStatus.PLANNED, OrderStatus.RELEASED}:
+                shortages.extend(service.material_shortage_report(order.id))
+        upcoming = service.get_upcoming_operations(limit=10)
+        backlog_preview = sorted(
+            (
+                (
+                    order,
+                    max(
+                        (plan for plan in order.operations if plan.scheduled_end),
+                        key=lambda plan: plan.scheduled_end,
+                        default=None,
+                    ),
+                )
+                for order in orders
+                if any(plan.scheduled_start for plan in order.operations)
+            ),
+            key=lambda entry: entry[1].scheduled_end if entry[1] else datetime.max,
+        )
+        low_stock = [
+            item
+            for item in inventory
+            if item.quantity_on_hand < max(item.reorder_point, item.safety_stock)
+        ]
+        return templates.TemplateResponse(
+            "dashboard.html",
+            {
+                "request": request,
+                "orders": orders,
+                "customers": customers,
+                "machines": machines,
+                "inventory": inventory,
+                "purchase_orders": purchase_orders,
+                "suppliers": suppliers,
+                "shortages": shortages,
+                "upcoming": upcoming,
+                "backlog_preview": backlog_preview,
+                "low_stock": low_stock,
+            },
+        )
+
+    @app.post("/schedule/backlog")
+    async def schedule_backlog(request: Request):
+        service: ERPService = request.app.state.erp_service
+        service.schedule_backlog()
+        return RedirectResponse("/", status_code=303)
+
+    @app.get("/planning")
+    async def planning_overview(request: Request):
+        service: ERPService = request.app.state.erp_service
+        options = service.planning_options
+        procurement_options = service.procurement_options
+        all_orders = service.orders.list()
+        orders = [
+            order
+            for order in all_orders
+            if order.status not in {OrderStatus.COMPLETED, OrderStatus.CANCELLED}
+        ]
+        orders.sort(
+            key=lambda order: (-int(order.priority), order.due_date, order.created_at)
+        )
+        customers = service.customers.list()
+        machines = service.machines.list()
+        calendars = service.shift_calendars.list()
+        upcoming = service.get_upcoming_operations(limit=25)
+        query = request.query_params
+        scheduled_count = query.get("scheduled")
+        operations_planned = query.get("operations")
+        overloaded_count = query.get("overloads")
+        purchase_created = query.get("purchases")
+        return templates.TemplateResponse(
+            "planning.html",
+            {
+                "request": request,
+                "planning_options": options,
+                "orders": orders,
+                "all_orders": all_orders,
+                "customers": customers,
+                "machines": machines,
+                "calendars": calendars,
+                "upcoming": upcoming,
+                "procurement_options": procurement_options,
+                "scheduled_count": int(scheduled_count)
+                if scheduled_count
+                else None,
+                "operations_planned": int(operations_planned)
+                if operations_planned
+                else None,
+                "overloaded_count": int(overloaded_count)
+                if overloaded_count
+                else None,
+                "purchase_created": int(purchase_created)
+                if purchase_created
+                else None,
+                "options_updated": "options" in query,
+            },
+        )
+
+    @app.post("/planning/options")
+    async def update_planning_options(
+        request: Request,
+        priority_weight: float = Form(...),
+        due_date_weight: float = Form(...),
+        horizon_days: int = Form(0),
+        max_orders_per_cycle: int = Form(0),
+        default_start_time: str = Form("06:00"),
+        setup_time_factor: float = Form(1.0),
+        gap_between_operations_minutes: int = Form(0),
+        auto_release_orders: Optional[str] = Form(None),
+    ):
+        service: ERPService = request.app.state.erp_service
+        try:
+            start_time = datetime.strptime(default_start_time, "%H:%M").time()
+        except ValueError:
+            start_time = service.planning_options.default_start_time
+        service.update_planning_options(
+            priority_weight=priority_weight,
+            due_date_weight=due_date_weight,
+            horizon_days=horizon_days,
+            max_orders_per_cycle=max_orders_per_cycle,
+            auto_release_orders=auto_release_orders is not None,
+            default_start_time=start_time,
+            setup_time_factor=setup_time_factor,
+            gap_between_operations_minutes=gap_between_operations_minutes,
+        )
+        redirect = "/planning?" + urlencode({"options": "updated"})
+        return RedirectResponse(redirect, status_code=303)
+
+    @app.post("/planning/run")
+    async def run_planning(
+        request: Request,
+        start_date: Optional[str] = Form(None),
+        start_time_value: Optional[str] = Form(None),
+        horizon_override: Optional[str] = Form(None),
+        max_orders: Optional[str] = Form(None),
+        plan_purchases: Optional[str] = Form(None),
+        auto_create_purchases: Optional[str] = Form(None),
+    ):
+        service: ERPService = request.app.state.erp_service
+        start_reference: Optional[datetime] = None
+        if start_date:
+            try:
+                date_part = datetime.strptime(start_date, "%Y-%m-%d").date()
+                time_text = (
+                    start_time_value
+                    if start_time_value
+                    else service.planning_options.default_start_time.strftime("%H:%M")
+                )
+                time_part = datetime.strptime(time_text, "%H:%M").time()
+                start_reference = datetime.combine(date_part, time_part)
+            except ValueError:
+                start_reference = None
+        horizon_value: Optional[int] = None
+        if horizon_override:
+            try:
+                horizon_value = max(int(horizon_override), 0)
+            except ValueError:
+                horizon_value = None
+        max_orders_value: Optional[int] = None
+        if max_orders:
+            try:
+                max_orders_value = max(int(max_orders), 0)
+            except ValueError:
+                max_orders_value = None
+        summaries = service.schedule_backlog(
+            start_reference=start_reference,
+            horizon_days=horizon_value,
+            max_orders=max_orders_value,
+        )
+        scheduled_count = len(summaries)
+        operations_planned = sum(
+            len(summary.scheduled_operations) for summary in summaries.values()
+        )
+        overloaded_machines = {
+            machine_id
+            for summary in summaries.values()
+            for machine_id in summary.overloaded_machines
+        }
+        purchase_created = 0
+        if plan_purchases is not None:
+            auto_create_flag = (
+                auto_create_purchases is not None
+            )
+            for summary in summaries.values():
+                planned = service.plan_material_purchases(
+                    summary.order_id,
+                    auto_create=auto_create_flag,
+                )
+                purchase_created += len(planned)
+        params = {
+            "scheduled": scheduled_count,
+            "operations": operations_planned,
+        }
+        if overloaded_machines:
+            params["overloads"] = len(overloaded_machines)
+        if purchase_created:
+            params["purchases"] = purchase_created
+        redirect = "/planning"
+        if params:
+            redirect += "?" + urlencode(params)
+        return RedirectResponse(redirect, status_code=303)
+
+    @app.post("/orders/{order_id}/schedule")
+
+    @app.get("/simulation")
+    async def simulation_overview(request: Request):
+        service: ERPService = request.app.state.erp_service
+        scenario_inputs = [None, None, None]
+        machine_lookup = {
+            machine.id: machine.name for machine in service.machines.list()
+        }
+        return templates.TemplateResponse(
+            "simulation.html",
+            {
+                "request": request,
+                "planning_options": service.planning_options,
+                "results": [],
+                "scenario_inputs": scenario_inputs,
+                "machine_lookup": machine_lookup,
+            },
+        )
+
+    @app.post("/simulation/run")
+    async def run_simulation(request: Request):
+        service: ERPService = request.app.state.erp_service
+        form = await request.form()
+        scenario_map = parse_scenario_form(form, service.planning_options.default_start_time)
+        scenarios = [scenario for _, scenario in sorted(scenario_map.items())]
+        results = service.simulate_planning_scenarios(scenarios)
+        scenario_inputs = [scenario_map.get(index) for index in range(1, 4)]
+        machine_lookup = {
+            machine.id: machine.name for machine in service.machines.list()
+        }
+        return templates.TemplateResponse(
+            "simulation.html",
+            {
+                "request": request,
+                "planning_options": service.planning_options,
+                "results": results,
+                "scenario_inputs": scenario_inputs,
+                "machine_lookup": machine_lookup,
+            },
+        )
+
+    @app.post("/orders/{order_id}/schedule")
+    async def schedule_order(order_id: str, request: Request):
+        service: ERPService = request.app.state.erp_service
+        service.schedule_operations(order_id)
+        return RedirectResponse("/", status_code=303)
+
+    @app.post("/orders/{order_id}/plan-purchase")
+    async def plan_purchase(order_id: str, request: Request):
+        service: ERPService = request.app.state.erp_service
+        service.plan_material_purchases(order_id, auto_create=True)
+        return RedirectResponse("/", status_code=303)
+
+    @app.get("/orders/{order_id}/documents")
+    async def order_documents(order_id: str, request: Request):
+        service: ERPService = request.app.state.erp_service
+        try:
+            order = service.orders.get(order_id)
+        except RecordNotFoundError:
+            return RedirectResponse("/planning", status_code=303)
+        instructions = service.generate_work_instructions(order_id)
+        machines = service.machines.list()
+        customers = service.customers.list()
+        customer = next((c for c in customers if c.id == order.customer_id), None)
+        return templates.TemplateResponse(
+            "documents.html",
+            {
+                "request": request,
+                "order": order,
+                "customer": customer,
+                "instructions": instructions,
+                "machines": {machine.id: machine for machine in machines},
+            },
+        )
+
+    @app.get("/suppliers")
+    async def supplier_overview(request: Request):
+        service: ERPService = request.app.state.erp_service
+        suppliers = sorted(
+            service.suppliers.list(), key=lambda supplier: supplier.name.lower()
+        )
+        default_supplier_id = suppliers[0].id if suppliers else ""
+        inventory = service.inventory.list()
+        evaluations = sorted(
+            service.supplier_evaluations.list(),
+            key=lambda evaluation: evaluation.evaluated_on,
+            reverse=True,
+        )
+        return templates.TemplateResponse(
+            "suppliers.html",
+            {
+                "request": request,
+                "suppliers": suppliers,
+                "default_supplier_id": default_supplier_id,
+                "inventory": inventory,
+                "evaluations": evaluations,
+                "processes": ManufacturingProcess,
+            },
+        )
+
+    @app.post("/suppliers")
+    async def create_supplier(
+        request: Request,
+        name: str = Form(...),
+        address: str = Form(...),
+        contact_person: str = Form(""),
+        contact_email: str = Form(""),
+        contact_phone: str = Form(""),
+        process_capabilities: str = Form(""),
+        material_item_ids: str = Form(""),
+    ):
+        service: ERPService = request.app.state.erp_service
+        processes = parse_processes(process_capabilities)
+        materials = [item_id for item_id in split_csv(material_item_ids)]
+        service.register_supplier(
+            name=name,
+            address=address,
+            contact_person=contact_person,
+            contact_email=contact_email,
+            contact_phone=contact_phone,
+            process_capabilities=processes,
+            material_item_ids=materials,
+        )
+        return RedirectResponse("/suppliers", status_code=303)
+
+    @app.post("/suppliers/{supplier_id}/evaluation")
+    async def add_supplier_evaluation(
+        supplier_id: str,
+        request: Request,
+        quality_score: float = Form(...),
+        delivery_reliability_score: float = Form(...),
+        communication_score: float = Form(...),
+        evaluated_on: Optional[str] = Form(None),
+        notes: str = Form(""),
+    ):
+        service: ERPService = request.app.state.erp_service
+        evaluation_date = (
+            datetime.strptime(evaluated_on, "%Y-%m-%d").date()
+            if evaluated_on
+            else None
+        )
+        service.record_supplier_evaluation(
+            supplier_id=supplier_id,
+            quality_score=quality_score,
+            delivery_reliability_score=delivery_reliability_score,
+            communication_score=communication_score,
+            evaluated_on=evaluation_date,
+            notes=notes,
+        )
+        return RedirectResponse("/suppliers", status_code=303)
+
+    @app.post("/suppliers/{supplier_id}/materials")
+    async def add_supplier_material(
+        supplier_id: str,
+        request: Request,
+        item_id: str = Form(...),
+    ):
+        service: ERPService = request.app.state.erp_service
+        try:
+            service.link_supplier_to_material(supplier_id, item_id)
+        except RecordNotFoundError:
+            pass
+        return RedirectResponse("/suppliers", status_code=303)
+
+    @app.get("/procurement")
+    async def procurement_overview(request: Request):
+        service: ERPService = request.app.state.erp_service
+        options = service.procurement_options
+        orders = [
+            order
+            for order in service.orders.list()
+            if order.status != OrderStatus.CANCELLED
+        ]
+        orders.sort(key=lambda order: (order.due_date, -int(order.priority)))
+        selected_order_id = request.query_params.get("order_id")
+        if not selected_order_id and orders:
+            selected_order_id = orders[0].id
+        shortages: List = []
+        selected_order = None
+        if selected_order_id:
+            try:
+                selected_order = service.orders.get(selected_order_id)
+                shortages = service.material_shortage_report(selected_order_id)
+            except RecordNotFoundError:
+                selected_order = None
+                shortages = []
+        purchase_orders = sorted(
+            service.purchase_orders.list(), key=lambda po: po.expected_receipt
+        )
+        inventory = service.inventory.list()
+        query = request.query_params
+        planned_count = query.get("planned")
+        created_count = query.get("created")
+        return templates.TemplateResponse(
+            "procurement.html",
+            {
+                "request": request,
+                "procurement_options": options,
+                "orders": orders,
+                "selected_order_id": selected_order_id,
+                "selected_order": selected_order,
+                "shortages": shortages,
+                "purchase_orders": purchase_orders,
+                "inventory": inventory,
+                "planned_count": int(planned_count) if planned_count else None,
+                "created_count": int(created_count) if created_count else None,
+                "options_updated": "options" in query,
+            },
+        )
+
+    @app.post("/procurement/options")
+    async def update_procurement_options(
+        request: Request,
+        reorder_multiplier: float = Form(...),
+        include_safety_stock: Optional[str] = Form(None),
+        expedite_high_priority_days: int = Form(0),
+        default_lead_time_days: int = Form(0),
+        auto_create_orders: Optional[str] = Form(None),
+    ):
+        service: ERPService = request.app.state.erp_service
+        service.update_procurement_options(
+            reorder_multiplier=reorder_multiplier,
+            include_safety_stock_gap=include_safety_stock is not None,
+            expedite_high_priority_days=expedite_high_priority_days,
+            default_lead_time_days=default_lead_time_days,
+            auto_create_orders=auto_create_orders is not None,
+        )
+        redirect = "/procurement?" + urlencode({"options": "updated"})
+        return RedirectResponse(redirect, status_code=303)
+
+    @app.post("/procurement/order/{order_id}/plan")
+    async def plan_procurement_for_order(
+        order_id: str,
+        request: Request,
+        reorder_multiplier: str = Form(""),
+        include_safety_stock_override: str = Form("inherit"),
+        expedite_high_priority_days: str = Form(""),
+        auto_create_override: str = Form("inherit"),
+    ):
+        service: ERPService = request.app.state.erp_service
+        try:
+            service.orders.get(order_id)
+        except RecordNotFoundError:
+            return RedirectResponse("/procurement", status_code=303)
+        multiplier_value: Optional[float] = None
+        if reorder_multiplier:
+            try:
+                multiplier_value = float(reorder_multiplier)
+            except ValueError:
+                multiplier_value = None
+        include_value: Optional[bool]
+        if include_safety_stock_override == "inherit":
+            include_value = None
+        else:
+            include_value = include_safety_stock_override == "yes"
+        auto_create_value: Optional[bool]
+        if auto_create_override == "inherit":
+            auto_create_value = None
+        else:
+            auto_create_value = auto_create_override == "yes"
+        expedite_value: Optional[int] = None
+        if expedite_high_priority_days:
+            try:
+                expedite_value = max(int(expedite_high_priority_days), 0)
+            except ValueError:
+                expedite_value = None
+        planned = service.plan_material_purchases(
+            order_id,
+            auto_create=auto_create_value,
+            reorder_multiplier=multiplier_value,
+            include_safety_stock=include_value,
+            expedite_high_priority_days=expedite_value,
+        )
+        options = service.procurement_options
+        actual_auto_create = (
+            auto_create_value if auto_create_value is not None else options.auto_create_orders
+        )
+        params = {
+            "order_id": order_id,
+            "planned": len(planned),
+        }
+        if actual_auto_create and planned:
+            params["created"] = len(planned)
+        redirect = "/procurement"
+        if params:
+            redirect += "?" + urlencode(params)
+        return RedirectResponse(redirect, status_code=303)
+
+    @app.get("/users")
+    async def user_overview(request: Request):
+        service: ERPService = request.app.state.erp_service
+        users = service.users.list()
+        users.sort(key=lambda entry: (entry.full_name or entry.username).lower())
+        return templates.TemplateResponse(
+            "users.html",
+            {
+                "request": request,
+                "users": users,
+                "roles": list(UserRole),
+            },
+        )
+
+    @app.post("/users")
+    async def create_user_endpoint(request: Request):
+        service: ERPService = request.app.state.erp_service
+        form = await request.form()
+        username = (form.get("username") or "").strip()
+        full_name = (form.get("full_name") or "").strip()
+        email = (form.get("email") or "").strip()
+        active_flag = form.get("is_active")
+        is_active = active_flag is None or active_flag.lower() in {"on", "true"}
+        roles_raw: Sequence[str] = []
+        if hasattr(form, "getlist"):
+            roles_raw = form.getlist("roles")
+        elif form.get("roles"):
+            roles_raw = [form.get("roles")]
+        roles = parse_user_roles(roles_raw)
+        if username:
+            service.create_user(
+                username=username,
+                full_name=full_name or username,
+                email=email,
+                roles=roles,
+                is_active=is_active,
+            )
+        return RedirectResponse("/users", status_code=303)
+
+    @app.post("/users/{user_id}/roles")
+    async def update_user_roles_endpoint(user_id: str, request: Request):
+        service: ERPService = request.app.state.erp_service
+        form = await request.form()
+        roles_raw: Sequence[str] = []
+        if hasattr(form, "getlist"):
+            roles_raw = form.getlist("roles")
+        elif form.get("roles"):
+            roles_raw = [form.get("roles")]
+        roles = parse_user_roles(roles_raw)
+        try:
+            service.update_user_roles(user_id, roles)
+        except RecordNotFoundError:
+            pass
+        return RedirectResponse("/users", status_code=303)
+
+    @app.post("/users/{user_id}/status")
+    async def update_user_status(user_id: str, request: Request):
+        service: ERPService = request.app.state.erp_service
+        form = await request.form()
+        state = (form.get("state") or "active").lower()
+        active = state == "active"
+        try:
+            service.set_user_active(user_id, active)
+        except RecordNotFoundError:
+            pass
+        return RedirectResponse("/users", status_code=303)
+
+    @app.get("/calendars")
+    async def calendar_overview(request: Request):
+        service: ERPService = request.app.state.erp_service
+        calendars = service.shift_calendars.list()
+        machines = service.machines.list()
+        return templates.TemplateResponse(
+            "calendars.html",
+            {
+                "request": request,
+                "calendars": calendars,
+                "machines": machines,
+            },
+        )
+
+    @app.post("/calendars")
+    async def create_calendar(
+        request: Request,
+        name: str = Form(...),
+        shift_definitions: str = Form(...),
+        non_working_days: str = Form(""),
+    ):
+        service: ERPService = request.app.state.erp_service
+        shifts = parse_shift_definitions(shift_definitions)
+        if not shifts:
+            return RedirectResponse("/calendars", status_code=303)
+        days = []
+        for token in split_csv(non_working_days):
+            try:
+                days.append(datetime.strptime(token, "%Y-%m-%d").date())
+            except ValueError:
+                continue
+        service.create_shift_calendar(name=name, shifts=shifts, non_working_days=days)
+        return RedirectResponse("/calendars", status_code=303)
+
+    @app.post("/machines/{machine_id}/calendar")
+    async def assign_calendar(machine_id: str, request: Request, calendar_id: str = Form(...)):
+        service: ERPService = request.app.state.erp_service
+        try:
+            service.assign_shift_calendar(machine_id, calendar_id)
+        except RecordNotFoundError:
+            pass
+        return RedirectResponse("/calendars", status_code=303)
+
+    @app.post("/calendars/{calendar_id}/non-working-day")
+    async def add_holiday(calendar_id: str, request: Request, day: str = Form(...)):
+        service: ERPService = request.app.state.erp_service
+        try:
+            parsed = datetime.strptime(day, "%Y-%m-%d").date()
+            service.add_non_working_day(calendar_id, parsed)
+        except (ValueError, RecordNotFoundError):
+            pass
+        return RedirectResponse("/calendars", status_code=303)
+
+    return app
+
+
+def parse_user_roles(values: Sequence[str]) -> List[UserRole]:
+    roles: List[UserRole] = []
+    for token in values:
+        normalized = token.strip().lower()
+        if not normalized:
+            continue
+        for role in UserRole:
+            if normalized in {role.value.lower(), role.name.lower()}:
+                roles.append(role)
+                break
+    return roles
+
+
+def parse_scenario_form(form: Mapping[str, str], default_start: time) -> Dict[int, PlanningScenario]:
+    scenarios: Dict[int, PlanningScenario] = {}
+    for index in range(1, 4):
+        prefix = f"scenario{index}_"
+        name = (form.get(prefix + "name") or "").strip()
+        if not name:
+            continue
+        description = (form.get(prefix + "description") or "").strip()
+
+        def parse_float(field: str) -> Optional[float]:
+            value = (form.get(prefix + field) or "").strip()
+            if not value:
+                return None
+            try:
+                return float(value)
+            except ValueError:
+                return None
+
+        def parse_int(field: str) -> Optional[int]:
+            value = (form.get(prefix + field) or "").strip()
+            if not value:
+                return None
+            try:
+                return int(value)
+            except ValueError:
+                return None
+
+        default_start_text = (form.get(prefix + "default_start") or "").strip()
+        default_start_time: Optional[time] = None
+        if default_start_text:
+            try:
+                default_start_time = datetime.strptime(default_start_text, "%H:%M").time()
+            except ValueError:
+                default_start_time = None
+
+        start_date = (form.get(prefix + "start_date") or "").strip()
+        start_time_text = (form.get(prefix + "start_time") or "").strip()
+        start_reference: Optional[datetime] = None
+        if start_date:
+            try:
+                date_value = datetime.strptime(start_date, "%Y-%m-%d").date()
+                base_time = default_start_time or default_start
+                time_value = datetime.strptime(start_time_text or base_time.strftime("%H:%M"), "%H:%M").time()
+                start_reference = datetime.combine(date_value, time_value)
+            except ValueError:
+                start_reference = None
+
+        auto_release_value = (form.get(prefix + "auto_release") or "inherit").strip().lower()
+        if auto_release_value in {"true", "on", "yes"}:
+            auto_release: Optional[bool] = True
+        elif auto_release_value in {"false", "off", "no"}:
+            auto_release = False
+        else:
+            auto_release = None
+
+        scenario = PlanningScenario(
+            name=name,
+            description=description,
+            priority_weight=parse_float("priority_weight"),
+            due_date_weight=parse_float("due_date_weight"),
+            horizon_days=parse_int("horizon"),
+            max_orders_per_cycle=parse_int("max_orders"),
+            auto_release_orders=auto_release,
+            default_start_time=default_start_time,
+            setup_time_factor=parse_float("setup_factor"),
+            gap_between_operations_minutes=parse_int("gap_minutes"),
+            start_reference=start_reference,
+            run_horizon_days=parse_int("run_horizon"),
+            run_max_orders=parse_int("run_max_orders"),
+        )
+        scenarios[index] = scenario
+    return scenarios
+
+
+def split_csv(values: str) -> List[str]:
+    return [value.strip() for value in values.split(",") if value.strip()]
+
+
+def parse_processes(value: str) -> Sequence[ManufacturingProcess]:
+    processes: List[ManufacturingProcess] = []
+    for token in split_csv(value):
+        for process in ManufacturingProcess:
+            if token.lower() in {process.value.lower(), process.name.lower()}:
+                processes.append(process)
+                break
+    return processes
+
+
+def parse_shift_definitions(definitions: str) -> List[Shift]:
+    shifts: List[Shift] = []
+    for line in definitions.splitlines():
+        if not line.strip():
+            continue
+        try:
+            name, start_str, end_str, weekdays_str = [part.strip() for part in line.split("|")]
+            start_time = datetime.strptime(start_str, "%H:%M").time()
+            end_time = datetime.strptime(end_str, "%H:%M").time()
+            weekdays = tuple(int(value) for value in weekdays_str.split(",") if value)
+            shifts.append(Shift(name=name, start_time=start_time, end_time=end_time, weekdays=weekdays))
+        except ValueError:
+            continue
+    return shifts
+
+
+def ensure_demo_data(service: ERPService) -> None:
+    if len(service.customers) > 0:
+        return
+
+    day_shift = service.create_shift_calendar(
+        name="Standard Zweischicht",
+        shifts=[
+            Shift(
+                name="Frühschicht",
+                start_time=time(6, 0),
+                end_time=time(14, 0),
+                weekdays=tuple(range(0, 5)),
+            ),
+            Shift(
+                name="Spätschicht",
+                start_time=time(14, 0),
+                end_time=time(22, 0),
+                weekdays=tuple(range(0, 5)),
+            ),
+        ],
+    )
+
+    customer = service.create_customer(
+        name="Sondermaschinen Müller GmbH",
+        address="Werkstraße 12, 32547 Bad Oeynhausen",
+        contact_person="Sabine Hartmann",
+        contact_email="s.hartmann@sondermueller.de",
+        contact_phone="+49 5731 12345",
+        industry="Automotive",
+    )
+
+    machines = [
+        service.register_machine(
+            name="DMG MORI CTX beta 800",
+            processes=[ManufacturingProcess.TURNING],
+            capacity_hours_per_week=45,
+            location="Fertigungshalle A",
+            manufacturer="DMG MORI",
+            shift_calendar_id=day_shift.id,
+        ),
+        service.register_machine(
+            name="Hermle C 42 U",
+            processes=[ManufacturingProcess.MILLING],
+            capacity_hours_per_week=50,
+            location="Fertigungshalle A",
+            manufacturer="Hermle",
+            shift_calendar_id=day_shift.id,
+        ),
+        service.register_machine(
+            name="Trumpf TruLaser 3030",
+            processes=[ManufacturingProcess.LASER_CUTTING],
+            capacity_hours_per_week=60,
+            location="Blechzentrum",
+            manufacturer="Trumpf",
+            shift_calendar_id=day_shift.id,
+        ),
+        service.register_machine(
+            name="Trumpf TruBend 5230",
+            processes=[ManufacturingProcess.BENDING],
+            capacity_hours_per_week=40,
+            location="Blechzentrum",
+            manufacturer="Trumpf",
+            shift_calendar_id=day_shift.id,
+        ),
+        service.register_machine(
+            name="Fronius TPSi 400",
+            processes=[ManufacturingProcess.WELDING],
+            capacity_hours_per_week=38,
+            location="Schweißerei",
+            manufacturer="Fronius",
+            shift_calendar_id=day_shift.id,
+        ),
+        service.register_machine(
+            name="Jung J630",
+            processes=[ManufacturingProcess.GRINDING],
+            capacity_hours_per_week=32,
+            location="Finish-Bereich",
+            manufacturer="Jung",
+            shift_calendar_id=day_shift.id,
+        ),
+        service.register_machine(
+            name="Behringer HBP 413 A",
+            processes=[ManufacturingProcess.SAWING],
+            capacity_hours_per_week=28,
+            location="Sägezentrum",
+            manufacturer="Behringer",
+            shift_calendar_id=day_shift.id,
+        ),
+    ]
+
+    sheet_steel = service.register_inventory_item(
+        name="Feinblech S355",
+        unit_of_measure="kg",
+        quantity_on_hand=180.0,
+        safety_stock=80.0,
+        reorder_point=100.0,
+        lead_time_days=5,
+    )
+    round_stock = service.register_inventory_item(
+        name="Rundmaterial 42CrMo4",
+        unit_of_measure="kg",
+        quantity_on_hand=120.0,
+        safety_stock=60.0,
+        reorder_point=90.0,
+        lead_time_days=7,
+    )
+    welding_wire = service.register_inventory_item(
+        name="Schweißdraht G3Si1",
+        unit_of_measure="kg",
+        quantity_on_hand=35.0,
+        safety_stock=20.0,
+        reorder_point=25.0,
+        lead_time_days=3,
+    )
+
+    steel_supplier = service.register_supplier(
+        name="Stahlhandel Westfalen GmbH",
+        address="Industriestraße 5, 44147 Dortmund",
+        contact_person="Peter König",
+        contact_email="verkauf@stahlwestfalen.de",
+        contact_phone="+49 231 98765",
+        material_item_ids=[sheet_steel.id, round_stock.id],
+    )
+    service.record_supplier_evaluation(
+        supplier_id=steel_supplier.id,
+        quality_score=4.5,
+        delivery_reliability_score=4.7,
+        communication_score=4.2,
+        notes="Zuverlässige Lieferungen",
+    )
+    welding_supplier = service.register_supplier(
+        name="Schweißtechnik OWL",
+        address="Im Gewerbepark 7, 32760 Detmold",
+        contact_person="Anja Krüger",
+        contact_email="service@schweisstechnik-owl.de",
+        contact_phone="+49 5231 445566",
+        material_item_ids=[welding_wire.id],
+    )
+    service.record_supplier_evaluation(
+        supplier_id=welding_supplier.id,
+        quality_score=4.8,
+        delivery_reliability_score=4.6,
+        communication_score=4.9,
+        notes="Gute Kommunikation",
+    )
+
+    operations_primary = [
+        service.build_operation(
+            name="Zuschnitt sägen",
+            process=ManufacturingProcess.SAWING,
+            duration_hours=1.5,
+            setup_time_hours=0.25,
+            description="Rohmaterial auf Länge bringen",
+            materials=[(round_stock.id, 45.0)],
+        ),
+        service.build_operation(
+            name="Drehen",
+            process=ManufacturingProcess.TURNING,
+            duration_hours=5.0,
+            setup_time_hours=0.5,
+            description="Alle Drehoperationen laut Zeichnung",
+        ),
+        service.build_operation(
+            name="Fräsen",
+            process=ManufacturingProcess.MILLING,
+            duration_hours=4.0,
+            setup_time_hours=0.75,
+            description="Bearbeitung prismatischer Konturen",
+        ),
+        service.build_operation(
+            name="Laserzuschnitt Blech",
+            process=ManufacturingProcess.LASER_CUTTING,
+            duration_hours=2.0,
+            setup_time_hours=0.25,
+            description="Laserschneiden von Blechkomponenten",
+            materials=[(sheet_steel.id, 60.0)],
+        ),
+        service.build_operation(
+            name="Kanten",
+            process=ManufacturingProcess.BENDING,
+            duration_hours=1.0,
+            setup_time_hours=0.25,
+            description="Abkanten der Blechsegmente",
+        ),
+        service.build_operation(
+            name="Schweißen",
+            process=ManufacturingProcess.WELDING,
+            duration_hours=3.5,
+            setup_time_hours=0.5,
+            description="Schweißen der Unterbaugruppen",
+            materials=[(welding_wire.id, 8.0)],
+        ),
+        service.build_operation(
+            name="Schleifen",
+            process=ManufacturingProcess.GRINDING,
+            duration_hours=2.5,
+            setup_time_hours=0.25,
+            description="Finish der Funktionsflächen",
+        ),
+    ]
+
+    operations_secondary = [
+        service.build_operation(
+            name="Rohling sägen",
+            process=ManufacturingProcess.SAWING,
+            duration_hours=1.0,
+            setup_time_hours=0.2,
+            description="Zuschnitt für Ersatzteilserie",
+            materials=[(round_stock.id, 20.0)],
+        ),
+        service.build_operation(
+            name="Fräsen Kleinteil",
+            process=ManufacturingProcess.MILLING,
+            duration_hours=2.5,
+            setup_time_hours=0.5,
+            description="Bearbeitung prismatischer Aufnahmen",
+        ),
+        service.build_operation(
+            name="Schweißen Unterbau",
+            process=ManufacturingProcess.WELDING,
+            duration_hours=1.0,
+            setup_time_hours=0.25,
+            description="Heften und Schweißen kleiner Baugruppe",
+            materials=[(welding_wire.id, 3.0)],
+        ),
+    ]
+
+    order_primary = service.create_production_order(
+        customer_id=customer.id,
+        reference="SO-2024-015",
+        due_date=date.today() + timedelta(days=14),
+        operations=operations_primary,
+        remarks="Komplexer Maschinenträger mit hoher Maßhaltigkeit",
+        priority=OrderPriority.HIGH,
+    )
+    order_secondary = service.create_production_order(
+        customer_id=customer.id,
+        reference="SO-2024-016",
+        due_date=date.today() + timedelta(days=10),
+        operations=operations_secondary,
+        remarks="Ersatzteilserie für Bestandsmaschine",
+        priority=OrderPriority.NORMAL,
+    )
+
+    service.schedule_backlog()
+    service.plan_material_purchases(order_primary.id, auto_create=True)
+
+    if len(service.users) == 0:
+        admin = service.create_user(
+            username="admin",
+            full_name="Hannah Planung",
+            email="hannah.planung@example.com",
+            roles=[UserRole.ADMIN, UserRole.PLANNER],
+        )
+        buyer = service.create_user(
+            username="buyer",
+            full_name="Jonas Einkauf",
+            email="jonas.einkauf@example.com",
+            roles=[UserRole.PURCHASER],
+        )
+        foreman = service.create_user(
+            username="meister",
+            full_name="Ute Fertigung",
+            email="ute.fertigung@example.com",
+            roles=[UserRole.PRODUCTION, UserRole.VIEWER],
+        )
+        service.record_user_login(admin.id)
+        service.record_user_login(buyer.id)
+        foreman.last_login = None
+        service.users.upsert(foreman.id, foreman)
+

--- a/erp_system/web/templates/base.html
+++ b/erp_system/web/templates/base.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}ERP Dashboard{% endblock %}</title>
+    <style>
+      :root {
+        --primary: #1f497d;
+        --secondary: #f2f4f8;
+        --accent: #e67e22;
+        --danger: #c0392b;
+        font-family: "Segoe UI", Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: var(--secondary);
+        color: #222;
+      }
+
+      a {
+        color: var(--primary);
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      header {
+        background: var(--primary);
+        color: white;
+        padding: 1.5rem 2rem;
+      }
+
+      nav a {
+        color: white;
+        margin-right: 1.5rem;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      nav a:hover {
+        text-decoration: underline;
+      }
+
+      main {
+        padding: 2rem;
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 1.5rem;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 0.5rem;
+      }
+
+      th,
+      td {
+        padding: 0.5rem 0.75rem;
+        text-align: left;
+        border-bottom: 1px solid #ddd;
+        vertical-align: top;
+      }
+
+      th {
+        background: #f7f9fb;
+        font-weight: 600;
+      }
+
+      .actions form {
+        display: inline-block;
+        margin-right: 0.25rem;
+      }
+
+      button,
+      input[type="submit"] {
+        background: var(--primary);
+        border: none;
+        color: white;
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.85rem;
+      }
+
+      button.secondary,
+      input.secondary {
+        background: #6c757d;
+      }
+
+      button.danger,
+      input.danger {
+        background: var(--danger);
+      }
+
+      form.inline {
+        display: inline-block;
+      }
+
+      .tag {
+        display: inline-block;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        background: #eef2f9;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--primary);
+      }
+
+      .tag.high {
+        background: #fdecea;
+        color: var(--danger);
+      }
+
+      .tag.critical {
+        background: #fff3cd;
+        color: #856404;
+      }
+
+      .status-badge {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: white;
+        padding: 0.2rem 0.5rem;
+        border-radius: 4px;
+      }
+
+      .status-PLANNED {
+        background: #6c757d;
+      }
+
+      .status-RELEASED {
+        background: #1abc9c;
+      }
+
+      .status-IN\ PROGRESS {
+        background: #3498db;
+      }
+
+      .status-COMPLETED {
+        background: #2ecc71;
+      }
+
+      .status-CANCELLED {
+        background: #7f8c8d;
+      }
+
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+      }
+
+      label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+
+      input,
+      select,
+      textarea {
+        width: 100%;
+        padding: 0.4rem 0.5rem;
+        border: 1px solid #ccd2d8;
+        border-radius: 4px;
+        font-size: 0.9rem;
+      }
+
+      input[type="checkbox"] {
+        width: auto;
+        margin-right: 0.35rem;
+      }
+
+      textarea {
+        min-height: 5rem;
+        resize: vertical;
+      }
+
+      .muted {
+        color: #6c757d;
+        font-size: 0.85rem;
+      }
+
+      .list-inline {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .list-inline li {
+        display: inline-block;
+        margin-right: 0.5rem;
+      }
+
+      .alert {
+        background: #e7f0fd;
+        border-left: 4px solid var(--primary);
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        margin-bottom: 1.5rem;
+      }
+
+      .alert.success {
+        background: #e6f4ea;
+        border-left-color: #2ecc71;
+      }
+
+      .alert.warning {
+        background: #fff4e5;
+        border-left-color: #e67e22;
+      }
+
+      .checkbox-inline {
+        display: flex;
+        align-items: center;
+        font-weight: 600;
+        gap: 0.5rem;
+      }
+
+      .checkbox-inline span {
+        font-weight: 400;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Sondermaschinenbau ERP</h1>
+      <nav>
+        <a href="/">Dashboard</a>
+        <a href="/planning">Feinplanung</a>
+        <a href="/simulation">Simulation</a>
+        <a href="/procurement">Einkauf</a>
+        <a href="/suppliers">Lieferanten</a>
+        <a href="/calendars">Schichtkalender</a>
+        <a href="/users">Benutzer</a>
+      </nav>
+    </header>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/erp_system/web/templates/calendars.html
+++ b/erp_system/web/templates/calendars.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}Schichtkalender{% endblock %}
+
+{% block content %}
+  <div class="card" style="margin-bottom: 2rem;">
+    <h2>Schichtkalender</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Schichten</th>
+          <th>Ausnahmen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for calendar in calendars %}
+          <tr>
+            <td><strong>{{ calendar.name }}</strong> <span class="muted">({{ calendar.id[:8] }})</span></td>
+            <td>
+              {% for shift in calendar.shifts %}
+                <div>
+                  <span class="tag">{{ shift.name }}</span>
+                  {{ shift.start_time.strftime("%H:%M") }} – {{ shift.end_time.strftime("%H:%M") }}<br />
+                  <span class="muted">Wochentage: {{ shift.weekdays | join(", ") }}</span>
+                </div>
+              {% else %}
+                <span class="muted">Keine Schichten definiert.</span>
+              {% endfor %}
+            </td>
+            <td>
+              {% for day in calendar.non_working_days|list|sort %}
+                <span class="tag">{{ day.strftime("%d.%m.%Y") }}</span>
+              {% else %}
+                <span class="muted">keine Einträge</span>
+              {% endfor %}
+              <form method="post" action="/calendars/{{ calendar.id }}/non-working-day" style="margin-top: 0.5rem;">
+                <input type="date" name="day" required />
+                <button type="submit" class="secondary">Feiertag hinzufügen</button>
+              </form>
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="3" class="muted">Noch keine Schichtkalender angelegt.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <h2>Neuen Kalender erstellen</h2>
+      <form method="post" action="/calendars">
+        <label for="cal_name">Bezeichnung</label>
+        <input id="cal_name" name="name" required />
+        <label for="shift_definitions">Schichten (eine pro Zeile, Format: Name|Start|Ende|Wochentage)</label>
+        <textarea id="shift_definitions" name="shift_definitions" placeholder="Frühschicht|06:00|14:00|0,1,2,3,4&#10;Spätschicht|14:00|22:00|0,1,2,3,4" required></textarea>
+        <label for="non_working_days">Feiertage (YYYY-MM-DD, Komma getrennt)</label>
+        <input id="non_working_days" name="non_working_days" />
+        <div style="margin-top: 1rem;">
+          <button type="submit">Kalender speichern</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Kalender zu Maschine zuordnen</h2>
+      <form method="post" action="/machines/{{ (machines|first).id if machines else '' }}/calendar">
+        <label for="machine_select">Maschine</label>
+        <select id="machine_select" name="machine_id" onchange="this.form.action='/machines/'+this.value+'/calendar'">
+          {% for machine in machines %}
+            <option value="{{ machine.id }}">{{ machine.name }} ({{ machine.shift_calendar_id or 'kein Kalender' }})</option>
+          {% endfor %}
+        </select>
+        <label for="calendar_id">Kalender</label>
+        <select id="calendar_id" name="calendar_id">
+          {% for calendar in calendars %}
+            <option value="{{ calendar.id }}">{{ calendar.name }}</option>
+          {% endfor %}
+        </select>
+        <div style="margin-top: 1rem;">
+          <button type="submit">Zuordnen</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/erp_system/web/templates/dashboard.html
+++ b/erp_system/web/templates/dashboard.html
@@ -1,0 +1,160 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+  <div class="grid" style="margin-bottom: 2rem;">
+    <div class="card">
+      <h2>Stammdaten</h2>
+      <p><strong>{{ customers|length }}</strong> Kunden</p>
+      <p><strong>{{ machines|length }}</strong> Maschinen</p>
+      <p><strong>{{ suppliers|length }}</strong> Lieferanten</p>
+    </div>
+    <div class="card">
+      <h2>Aufträge</h2>
+      <p><strong>{{ orders|length }}</strong> Produktionsaufträge</p>
+      <p><strong>{{ purchase_orders|length }}</strong> offene Bestellungen</p>
+      <form action="/schedule/backlog" method="post">
+        <button type="submit">Backlog nach Priorität planen</button>
+      </form>
+      <p class="muted" style="margin-top: 0.5rem;">Erweiterte Parameter unter <a href="/planning">Feinplanung</a>.</p>
+    </div>
+    <div class="card">
+      <h2>Bestand</h2>
+      <p><strong>{{ inventory|length }}</strong> Materialien gepflegt</p>
+      <p><strong>{{ low_stock|length }}</strong> Artikel unter Meldebestand</p>
+    </div>
+  </div>
+
+  <div class="card" style="margin-bottom: 2rem;">
+    <h2>Produktionsaufträge</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Auftrag</th>
+          <th>Kunde</th>
+          <th>Fällig</th>
+          <th>Priorität</th>
+          <th>Status</th>
+          <th>Aktionen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for order in orders %}
+          {% set customer = customers | selectattr("id", "equalto", order.customer_id) | first %}
+          <tr>
+            <td>{{ order.reference }}</td>
+            <td>{{ customer.name if customer else "Unbekannt" }}</td>
+            <td>{{ order.due_date.strftime("%d.%m.%Y") }}</td>
+            {% set priority_name = order.priority.name.lower() %}
+            <td><span class="tag {{ 'critical' if priority_name == 'critical' else 'high' if priority_name == 'high' else '' }}">{{ order.priority.label }}</span></td>
+            <td><span class="status-badge status-{{ order.status.name }}">{{ order.status.value }}</span></td>
+            <td class="actions">
+              <form action="/orders/{{ order.id }}/schedule" method="post">
+                <input type="submit" value="Planen" />
+              </form>
+              <form action="/orders/{{ order.id }}/plan-purchase" method="post">
+                <input type="submit" value="Einkauf" class="secondary" />
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="grid" style="margin-bottom: 2rem;">
+    <div class="card">
+      <h2>Nächste Operationen</h2>
+      <ul class="list-inline" style="display: block; list-style: none; padding: 0;">
+        {% for entry in upcoming %}
+          {% set order_obj = orders | selectattr("id", "equalto", entry.order_id) | first %}
+          {% set operation_plan = order_obj.operations | selectattr("operation.id", "equalto", entry.operation_id) | first if order_obj else None %}
+          {% set machine_obj = machines | selectattr("id", "equalto", entry.machine_id) | first %}
+          <li style="display: block; margin-bottom: 0.6rem;">
+            <strong>{{ entry.start.strftime("%d.%m %H:%M") }}</strong>
+            – {{ entry.order_priority.label }} –
+            {{ operation_plan.operation.name if operation_plan else entry.operation_id }}
+            auf {{ machine_obj.name if machine_obj else entry.machine_id }}
+          </li>
+        {% else %}
+          <li>Keine geplanten Operationen.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="card">
+      <h2>Materialengpässe</h2>
+      <ul class="list-inline" style="display: block; list-style: none; padding: 0;">
+        {% for shortage in shortages %}
+          <li style="display: block; margin-bottom: 0.6rem;">
+            <strong>{{ shortage.name }}</strong><br />
+            Bedarf: {{ "%.1f"|format(shortage.required_quantity) }} – Prognose: {{ "%.1f"|format(shortage.projected_on_hand) }}<br />
+            Empfehlung: {{ "%.1f"|format(shortage.reorder_recommendation) }}
+            {% if shortage.recommended_supplier_name %}
+              <span class="muted">Lieferant: {{ shortage.recommended_supplier_name }}</span>
+            {% endif %}
+          </li>
+        {% else %}
+          <li>Aktuell keine kritischen Bedarfe.</li>
+        {% endfor %}
+      </ul>
+      <p class="muted" style="margin-top: 0.5rem;">Detailplanung im Bereich <a href="/procurement">Einkauf</a>.</p>
+    </div>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <h2>Bestände</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Artikel</th>
+            <th>Bestand</th>
+            <th>Sicherheitsbestand</th>
+            <th>Meldebestand</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in inventory %}
+            <tr>
+              <td>{{ item.name }}</td>
+              <td>{{ "%.1f"|format(item.quantity_on_hand) }} {{ item.unit_of_measure }}</td>
+              <td>{{ "%.1f"|format(item.safety_stock) }}</td>
+              <td>{{ "%.1f"|format(item.reorder_point) }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="card">
+      <h2>Offene Bestellungen</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Lieferant</th>
+            <th>Artikel</th>
+            <th>Menge</th>
+            <th>Liefertermin</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for po in purchase_orders %}
+            {% set item = inventory | selectattr("id", "equalto", po.item_id) | first %}
+            <tr>
+              <td>{{ po.supplier_name or po.supplier_id }}</td>
+              <td>{{ item.name if item else po.item_id }}</td>
+              <td>{{ "%.1f"|format(po.quantity) }}</td>
+              <td>{{ po.expected_receipt.strftime("%d.%m.%Y") }}</td>
+              <td>{{ po.status }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5" class="muted">Noch keine Bestellungen angelegt.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{% endblock %}

--- a/erp_system/web/templates/documents.html
+++ b/erp_system/web/templates/documents.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block title %}Fertigungsunterlagen{% endblock %}
+
+{% block content %}
+  <div class="card" style="margin-bottom: 1.5rem;">
+    <h2>Fertigungsunterlagen für {{ order.reference }}</h2>
+    <p>
+      Kunde: {{ customer.name if customer else 'Unbekannter Kunde' }}<br />
+      Fälligkeit: {{ order.due_date.strftime('%d.%m.%Y') }}<br />
+      Priorität: {{ order.priority.label }}<br />
+      Status: {{ order.status.value }}
+    </p>
+    <a href="/planning">Zurück zur Feinplanung</a>
+  </div>
+
+  {% for instruction in instructions %}
+    <div class="card" style="margin-bottom: 1.5rem;">
+      <h3>{{ instruction.sequence }}. {{ instruction.operation_name }}</h3>
+      <p class="muted">
+        Prozess: {{ instruction.process.value }}
+        {% if instruction.machine_name %}
+          &middot; Maschine: {{ instruction.machine_name }}
+        {% elif instruction.machine_id %}
+          &middot; Maschine: {{ machines[instruction.machine_id].name if instruction.machine_id in machines else instruction.machine_id }}
+        {% endif %}
+      </p>
+      {% if instruction.instructions %}
+        <h4>Arbeitsanweisungen</h4>
+        <ul>
+          {% for step in instruction.instructions %}
+            <li>{{ step }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      {% if instruction.checklist %}
+        <h4>Checkliste</h4>
+        <ul>
+          {% for item in instruction.checklist %}
+            <li>
+              {% if not item.mandatory %}<span class="muted">(optional)</span> {% endif %}
+              {{ item.description }}
+              {% if item.reference %}<span class="muted">&ndash; {{ item.reference }}</span>{% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  {% else %}
+    <div class="card">
+      <p class="muted">Es konnten keine Arbeitsunterlagen generiert werden. Planen Sie den Auftrag, um Operationen zuzuordnen.</p>
+    </div>
+  {% endfor %}
+{% endblock %}

--- a/erp_system/web/templates/planning.html
+++ b/erp_system/web/templates/planning.html
@@ -1,0 +1,194 @@
+{% extends "base.html" %}
+
+{% block title %}Feinplanung{% endblock %}
+
+{% block content %}
+  {% if scheduled_count or operations_planned or overloaded_count or purchase_created %}
+    <div class="alert success">
+      <strong>Planung aktualisiert.</strong>
+      {% if scheduled_count %} {{ scheduled_count }} Auftrag{% if scheduled_count != 1 %}e{% endif %} verarbeitet.{% endif %}
+      {% if operations_planned %} Insgesamt {{ operations_planned }} Operationen eingeplant.{% endif %}
+      {% if overloaded_count %} {{ overloaded_count }} Maschine{% if overloaded_count != 1 %}n{% endif %} über dem Wochenbudget.{% endif %}
+      {% if purchase_created %} {{ purchase_created }} Beschaffungsvorschlag{% if purchase_created != 1 %}e{% endif %} erstellt.{% endif %}
+    </div>
+  {% elif options_updated %}
+    <div class="alert">
+      Planungseinstellungen wurden gespeichert.
+    </div>
+  {% endif %}
+
+  <div class="grid" style="margin-bottom: 2rem;">
+    <div class="card">
+      <h2>Planungsparameter</h2>
+      <form method="post" action="/planning/options">
+        <div class="form-grid">
+          <div>
+            <label for="priority_weight">Gewichtung Priorität</label>
+            <input id="priority_weight" name="priority_weight" type="number" min="0.1" step="0.1" value="{{ '%.2f'|format(planning_options.priority_weight) }}" required />
+          </div>
+          <div>
+            <label for="due_date_weight">Gewichtung Fälligkeit</label>
+            <input id="due_date_weight" name="due_date_weight" type="number" min="0" step="0.1" value="{{ '%.2f'|format(planning_options.due_date_weight) }}" required />
+          </div>
+          <div>
+            <label for="horizon_days">Planungshorizont (Tage)</label>
+            <input id="horizon_days" name="horizon_days" type="number" min="0" value="{{ planning_options.horizon_days }}" />
+          </div>
+          <div>
+            <label for="max_orders_per_cycle">Max. Aufträge pro Lauf</label>
+            <input id="max_orders_per_cycle" name="max_orders_per_cycle" type="number" min="0" value="{{ planning_options.max_orders_per_cycle }}" />
+          </div>
+          <div>
+            <label for="setup_time_factor">Rüstzeit-Faktor</label>
+            <input id="setup_time_factor" name="setup_time_factor" type="number" min="0" step="0.05" value="{{ '%.2f'|format(planning_options.setup_time_factor) }}" />
+          </div>
+          <div>
+            <label for="gap_between_operations_minutes">Puffer zwischen Operationen (min)</label>
+            <input id="gap_between_operations_minutes" name="gap_between_operations_minutes" type="number" min="0" value="{{ planning_options.gap_between_operations_minutes }}" />
+          </div>
+          <div>
+            <label for="default_start_time">Standard-Schichtbeginn</label>
+            <input id="default_start_time" name="default_start_time" type="time" value="{{ planning_options.default_start_time.strftime('%H:%M') }}" />
+          </div>
+        </div>
+        <label class="checkbox-inline" style="margin-top: 0.75rem;">
+          <input type="checkbox" name="auto_release_orders" {% if planning_options.auto_release_orders %}checked{% endif %} />
+          <span>Aufträge nach erfolgreicher Planung automatisch freigeben</span>
+        </label>
+        <div style="margin-top: 1rem;">
+          <button type="submit">Einstellungen speichern</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Backlog planen</h2>
+      <form method="post" action="/planning/run">
+        <div class="form-grid">
+          <div>
+            <label for="run_start_date">Startdatum</label>
+            <input id="run_start_date" name="start_date" type="date" />
+          </div>
+          <div>
+            <label for="run_start_time">Startzeit</label>
+            <input id="run_start_time" name="start_time_value" type="time" placeholder="{{ planning_options.default_start_time.strftime('%H:%M') }}" />
+          </div>
+          <div>
+            <label for="run_horizon">Horizont (Tage)</label>
+            <input id="run_horizon" name="horizon_override" type="number" min="0" placeholder="{{ planning_options.horizon_days }}" />
+          </div>
+          <div>
+            <label for="run_limit">Auftragslimit</label>
+            <input id="run_limit" name="max_orders" type="number" min="0" placeholder="{{ planning_options.max_orders_per_cycle }}" />
+          </div>
+        </div>
+        <label class="checkbox-inline" style="margin-top: 0.75rem;">
+          <input type="checkbox" name="plan_purchases" />
+          <span>Materialbedarf nach Planung bewerten</span>
+        </label>
+        <label class="checkbox-inline" style="margin-top: 0.35rem;">
+          <input type="checkbox" name="auto_create_purchases" />
+          <span>Beschaffungen sofort anlegen (benötigt Materialbewertung, Standard: {{ 'aktiv' if procurement_options.auto_create_orders else 'deaktiviert' }})</span>
+        </label>
+        <p class="muted" style="margin-top: 0.5rem;">
+          Detailparameter zur Beschaffung finden Sie im Bereich <a href="/procurement">Einkauf</a>.
+        </p>
+        <div style="margin-top: 1rem;">
+          <button type="submit">Planung ausführen</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="card" style="margin-bottom: 2rem;">
+    <h2>Auftragsübersicht</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Auftrag</th>
+          <th>Kunde</th>
+          <th>Fälligkeit</th>
+          <th>Priorität</th>
+          <th>Status</th>
+          <th>Operationen</th>
+          <th>Geplantes Ende</th>
+          <th>Unterlagen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for order in orders %}
+          {% set customer = customers | selectattr('id', 'equalto', order.customer_id) | first %}
+          {% set scheduled_ops = order.operations | selectattr('scheduled_end') | list %}
+          {% set last_plan = scheduled_ops | max(attribute='scheduled_end') if scheduled_ops else None %}
+          <tr>
+            <td><strong>{{ order.reference }}</strong></td>
+            <td>{{ customer.name if customer else 'Unbekannt' }}</td>
+            <td>{{ order.due_date.strftime('%d.%m.%Y') }}</td>
+            <td>{{ order.priority.label }}</td>
+            <td>{{ order.status.value }}</td>
+            <td>{{ order.operations|length }}</td>
+            <td>
+              {% if last_plan %}
+                {{ last_plan.scheduled_end.strftime('%d.%m.%Y %H:%M') }}
+              {% else %}
+                <span class="muted">nicht geplant</span>
+              {% endif %}
+            </td>
+            <td>
+              <a href="/orders/{{ order.id }}/documents">Anzeigen</a>
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="7" class="muted">Noch keine auftragsrelevanten Daten vorhanden.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <h2>Nächste Operationen</h2>
+      <ul class="list-inline" style="display: block; list-style: none; padding: 0;">
+        {% for entry in upcoming %}
+          {% set order_obj = all_orders | selectattr('id', 'equalto', entry.order_id) | first %}
+          {% set operation_plan = order_obj.operations | selectattr('operation.id', 'equalto', entry.operation_id) | first if order_obj else None %}
+          {% set machine_obj = machines | selectattr('id', 'equalto', entry.machine_id) | first %}
+          <li style="display: block; margin-bottom: 0.6rem;">
+            <strong>{{ entry.start.strftime('%d.%m %H:%M') }}</strong>
+            – {{ entry.order_priority.label }} –
+            {{ operation_plan.operation.name if operation_plan else entry.operation_id }}
+            auf {{ machine_obj.name if machine_obj else entry.machine_id }}
+            <span class="muted">bis {{ entry.end.strftime('%d.%m %H:%M') }}</span>
+          </li>
+        {% else %}
+          <li>Keine geplanten Operationen vorhanden.</li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    <div class="card">
+      <h2>Maschinenkapazitäten</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Maschine</th>
+            <th>Kapazität</th>
+            <th>Kalender</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for machine in machines %}
+            {% set calendar = calendars | selectattr('id', 'equalto', machine.shift_calendar_id) | first %}
+            <tr>
+              <td>{{ machine.name }}</td>
+              <td>{{ '%.1f'|format(machine.capacity_hours_per_week) }} h/Woche</td>
+              <td>{{ calendar.name if calendar else 'kein Kalender' }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{% endblock %}

--- a/erp_system/web/templates/procurement.html
+++ b/erp_system/web/templates/procurement.html
@@ -1,0 +1,162 @@
+{% extends "base.html" %}
+
+{% block title %}Einkauf{% endblock %}
+
+{% block content %}
+  {% if planned_count or created_count %}
+    <div class="alert success">
+      <strong>Beschaffung berechnet.</strong>
+      {% if planned_count %} {{ planned_count }} Vorschlag{% if planned_count != 1 %}e{% endif %} erstellt.{% endif %}
+      {% if created_count %} {{ created_count }} Bestellung{% if created_count != 1 %}en{% endif %} direkt angelegt.{% endif %}
+    </div>
+  {% elif options_updated %}
+    <div class="alert">
+      Beschaffungsparameter wurden gespeichert.
+    </div>
+  {% endif %}
+
+  <div class="grid" style="margin-bottom: 2rem;">
+    <div class="card">
+      <h2>Beschaffungsparameter</h2>
+      <form method="post" action="/procurement/options">
+        <div class="form-grid">
+          <div>
+            <label for="reorder_multiplier">Bestellmultiplikator</label>
+            <input id="reorder_multiplier" name="reorder_multiplier" type="number" min="0" step="0.05" value="{{ '%.2f'|format(procurement_options.reorder_multiplier) }}" />
+          </div>
+          <div>
+            <label for="default_lead_time_days">Standard-Lieferzeit (Tage)</label>
+            <input id="default_lead_time_days" name="default_lead_time_days" type="number" min="0" value="{{ procurement_options.default_lead_time_days }}" />
+          </div>
+          <div>
+            <label for="expedite_high_priority_days">Expressverkürzung für hohe Priorität (Tage)</label>
+            <input id="expedite_high_priority_days" name="expedite_high_priority_days" type="number" min="0" value="{{ procurement_options.expedite_high_priority_days }}" />
+          </div>
+        </div>
+        <label class="checkbox-inline" style="margin-top: 0.75rem;">
+          <input type="checkbox" name="include_safety_stock" {% if procurement_options.include_safety_stock_gap %}checked{% endif %} />
+          <span>Sicherheitsbestand bei Bedarfsermittlung berücksichtigen</span>
+        </label>
+        <label class="checkbox-inline" style="margin-top: 0.35rem;">
+          <input type="checkbox" name="auto_create_orders" {% if procurement_options.auto_create_orders %}checked{% endif %} />
+          <span>Bestellungen automatisch anlegen</span>
+        </label>
+        <div style="margin-top: 1rem;">
+          <button type="submit">Einstellungen speichern</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Bedarf planen</h2>
+      {% set form_order = selected_order_id if selected_order_id else (orders[0].id if orders else '') %}
+      <form method="post" action="/procurement/order/{{ form_order }}/plan">
+        <label for="procurement_order">Auftrag</label>
+        <select id="procurement_order" name="order_id" onchange="this.form.action='/procurement/order/'+this.value+'/plan'">
+          {% for order in orders %}
+            <option value="{{ order.id }}" {% if order.id == selected_order_id %}selected{% endif %}>{{ order.reference }} – fällig {{ order.due_date.strftime('%d.%m.%Y') }}</option>
+          {% endfor %}
+        </select>
+        <div class="form-grid" style="margin-top: 1rem;">
+          <div>
+            <label for="override_multiplier">Multiplikator überschreiben</label>
+            <input id="override_multiplier" name="reorder_multiplier" type="number" min="0" step="0.05" placeholder="{{ '%.2f'|format(procurement_options.reorder_multiplier) }}" />
+          </div>
+          <div>
+            <label for="override_expedite">Expressverkürzung (Tage)</label>
+            <input id="override_expedite" name="expedite_high_priority_days" type="number" min="0" placeholder="{{ procurement_options.expedite_high_priority_days }}" />
+          </div>
+        </div>
+        <div class="form-grid" style="margin-top: 1rem;">
+          <div>
+            <label for="override_safety">Sicherheitsbestand</label>
+            <select id="override_safety" name="include_safety_stock_override">
+              <option value="inherit">Globale Einstellung ({{ 'berücksichtigt' if procurement_options.include_safety_stock_gap else 'ignoriert' }})</option>
+              <option value="yes">Berücksichtigen</option>
+              <option value="no">Ignorieren</option>
+            </select>
+          </div>
+          <div>
+            <label for="override_auto_create">Bestellungen</label>
+            <select id="override_auto_create" name="auto_create_override">
+              <option value="inherit">Globale Einstellung ({{ 'automatisch' if procurement_options.auto_create_orders else 'geplant' }})</option>
+              <option value="yes">Sofort anlegen</option>
+              <option value="no">Nur Vorschläge</option>
+            </select>
+          </div>
+        </div>
+        <p class="muted" style="margin-top: 0.5rem;">Leere Felder übernehmen automatisch die aktuellen Grundeinstellungen.</p>
+        <div style="margin-top: 1rem;">
+          <button type="submit" {% if not orders %}disabled{% endif %}>Bedarf planen</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="card" style="margin-bottom: 2rem;">
+    <h2>Materialbedarf</h2>
+    {% if selected_order %}
+      <p class="muted">Auftrag {{ selected_order.reference }} – Fälligkeit {{ selected_order.due_date.strftime('%d.%m.%Y') }}.</p>
+    {% endif %}
+    <table>
+      <thead>
+        <tr>
+          <th>Material</th>
+          <th>Bedarf</th>
+          <th>Prognose Bestand</th>
+          <th>Sicherheitslücke</th>
+          <th>Empfehlung</th>
+          <th>Lieferant</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for shortage in shortages %}
+          {% set item = inventory | selectattr('id', 'equalto', shortage.item_id) | first %}
+          <tr>
+            <td>{{ shortage.name or (item.name if item else shortage.item_id) }}</td>
+            <td>{{ '%.1f'|format(shortage.required_quantity) }}</td>
+            <td>{{ '%.1f'|format(shortage.projected_on_hand) }}</td>
+            <td>{{ '%.1f'|format(shortage.shortage) }}</td>
+            <td>{{ '%.1f'|format(shortage.reorder_recommendation) }}</td>
+            <td>{{ shortage.recommended_supplier_name or '—' }}</td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="6" class="muted">Für den ausgewählten Auftrag bestehen aktuell keine Engpässe.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Offene Bestellungen</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Lieferant</th>
+          <th>Artikel</th>
+          <th>Menge</th>
+          <th>Liefertermin</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for po in purchase_orders %}
+          {% set item = inventory | selectattr('id', 'equalto', po.item_id) | first %}
+          <tr>
+            <td>{{ po.supplier_name or po.supplier_id }}</td>
+            <td>{{ item.name if item else po.item_id }}</td>
+            <td>{{ '%.1f'|format(po.quantity) }}</td>
+            <td>{{ po.expected_receipt.strftime('%d.%m.%Y') }}</td>
+            <td>{{ po.status }}</td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="5" class="muted">Keine Bestellungen vorhanden.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/erp_system/web/templates/simulation.html
+++ b/erp_system/web/templates/simulation.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+
+{% block title %}Simulation{% endblock %}
+
+{% block content %}
+  <div class="card" style="margin-bottom: 1.5rem;">
+    <h2>Planungsszenarien simulieren</h2>
+    <p class="muted">
+      Vergleichen Sie alternative Einstellungen für Prioritäten, Horizonte und Startzeiten.
+      Für jedes Szenario können Sie optionale Abweichungen vom globalen Parameter-Set festlegen
+      sowie Startdatum und Laufhorizont der Simulation bestimmen.
+    </p>
+  </div>
+
+  <form method="post" action="/simulation/run">
+    <div class="grid">
+      {% for index in range(1, 4) %}
+        {% set scenario = scenario_inputs[index-1] if scenario_inputs and scenario_inputs|length >= index else None %}
+        <div class="card">
+          <h3>Szenario {{ index }}</h3>
+          <div class="form-grid">
+            <div>
+              <label for="scenario{{ index }}_name">Name</label>
+              <input id="scenario{{ index }}_name" name="scenario{{ index }}_name" value="{{ scenario.name if scenario else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_description">Beschreibung</label>
+              <input id="scenario{{ index }}_description" name="scenario{{ index }}_description" value="{{ scenario.description if scenario else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_priority_weight">Gewichtung Priorität</label>
+              <input id="scenario{{ index }}_priority_weight" name="scenario{{ index }}_priority_weight" type="number" step="0.1" min="0" value="{{ '%.2f'|format(scenario.priority_weight) if scenario and scenario.priority_weight is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_due_date_weight">Gewichtung Fälligkeit</label>
+              <input id="scenario{{ index }}_due_date_weight" name="scenario{{ index }}_due_date_weight" type="number" step="0.1" min="0" value="{{ '%.2f'|format(scenario.due_date_weight) if scenario and scenario.due_date_weight is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_horizon">Horizont (Tage)</label>
+              <input id="scenario{{ index }}_horizon" name="scenario{{ index }}_horizon" type="number" min="0" value="{{ scenario.horizon_days if scenario and scenario.horizon_days is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_max_orders">Max. Aufträge</label>
+              <input id="scenario{{ index }}_max_orders" name="scenario{{ index }}_max_orders" type="number" min="0" value="{{ scenario.max_orders_per_cycle if scenario and scenario.max_orders_per_cycle is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_setup_factor">Rüstzeitfaktor</label>
+              <input id="scenario{{ index }}_setup_factor" name="scenario{{ index }}_setup_factor" type="number" step="0.05" min="0" value="{{ '%.2f'|format(scenario.setup_time_factor) if scenario and scenario.setup_time_factor is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_gap_minutes">Puffer (Minuten)</label>
+              <input id="scenario{{ index }}_gap_minutes" name="scenario{{ index }}_gap_minutes" type="number" min="0" value="{{ scenario.gap_between_operations_minutes if scenario and scenario.gap_between_operations_minutes is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_default_start">Schichtbeginn</label>
+              <input id="scenario{{ index }}_default_start" name="scenario{{ index }}_default_start" type="time" value="{{ scenario.default_start_time.strftime('%H:%M') if scenario and scenario.default_start_time else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_auto_release">Freigabe</label>
+              <select id="scenario{{ index }}_auto_release" name="scenario{{ index }}_auto_release">
+                {% set auto_val = 'inherit' %}
+                {% if scenario and scenario.auto_release_orders is not none %}
+                  {% set auto_val = 'true' if scenario.auto_release_orders else 'false' %}
+                {% endif %}
+                <option value="inherit" {% if auto_val == 'inherit' %}selected{% endif %}>Global</option>
+                <option value="true" {% if auto_val == 'true' %}selected{% endif %}>Aktiv</option>
+                <option value="false" {% if auto_val == 'false' %}selected{% endif %}>Deaktiv</option>
+              </select>
+            </div>
+            <div>
+              <label for="scenario{{ index }}_start_date">Startdatum</label>
+              <input id="scenario{{ index }}_start_date" name="scenario{{ index }}_start_date" type="date" value="{{ scenario.start_reference.strftime('%Y-%m-%d') if scenario and scenario.start_reference else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_start_time">Startzeit</label>
+              <input id="scenario{{ index }}_start_time" name="scenario{{ index }}_start_time" type="time" value="{{ scenario.start_reference.strftime('%H:%M') if scenario and scenario.start_reference else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_run_horizon">Lauf-Horizont (Tage)</label>
+              <input id="scenario{{ index }}_run_horizon" name="scenario{{ index }}_run_horizon" type="number" min="0" value="{{ scenario.run_horizon_days if scenario and scenario.run_horizon_days is not none else '' }}" />
+            </div>
+            <div>
+              <label for="scenario{{ index }}_run_max_orders">Lauf-Auftragslimit</label>
+              <input id="scenario{{ index }}_run_max_orders" name="scenario{{ index }}_run_max_orders" type="number" min="0" value="{{ scenario.run_max_orders if scenario and scenario.run_max_orders is not none else '' }}" />
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <div style="margin-top: 1rem;">
+      <button type="submit">Simulation starten</button>
+    </div>
+  </form>
+
+  {% if results %}
+    <div class="card" style="margin-top: 2rem;">
+      <h2>Simulationsergebnisse</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Szenario</th>
+            <th>Aufträge</th>
+            <th>Operationen</th>
+            <th>Überlastete Maschinen</th>
+            <th>Letzte Fertigstellung</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for result in results %}
+            {% set last_finish = result.completion_times.values() | max if result.completion_times else None %}
+            <tr>
+              <td>{{ result.scenario.name }}</td>
+              <td>{{ result.scheduled_orders }}</td>
+              <td>{{ result.total_operations }}</td>
+              <td>{{ result.overloaded_machines|length }}</td>
+              <td>{% if last_finish %}{{ last_finish.strftime('%d.%m.%Y %H:%M') }}{% else %}<span class="muted">keine Planung</span>{% endif %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="grid" style="margin-top: 1.5rem;">
+      {% for result in results %}
+        <div class="card">
+          <h3>{{ result.scenario.name }}</h3>
+          <p class="muted">Berechnete Parameter basieren auf dem aktuellen Satz und den Szenario-Overrides.</p>
+          <h4>Maschinenlast</h4>
+          <ul>
+            {% for machine_id, load in result.machine_loads.items() %}
+              {% set machine_name = machine_lookup.get(machine_id) if machine_lookup else None %}
+              <li>
+                {% if machine_name %}
+                  {{ machine_name }} <span class="muted">({{ machine_id }})</span>
+                {% else %}
+                  {{ machine_id }}
+                {% endif %}: {{ '%.2f'|format(load) }} h
+                {% if machine_id in result.overloaded_machines %}
+                  <span class="muted">(Überlast {{ '%.2f'|format(result.overloaded_machines[machine_id]) }} h)</span>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          {% if result.completion_times %}
+            <h4>Fertigstellung</h4>
+            <ul>
+              {% for order_id, finish in result.completion_times.items() %}
+                <li>{{ order_id }} &ndash; {{ finish.strftime('%d.%m.%Y %H:%M') }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/erp_system/web/templates/suppliers.html
+++ b/erp_system/web/templates/suppliers.html
@@ -1,0 +1,187 @@
+{% extends "base.html" %}
+
+{% block title %}Lieferanten{% endblock %}
+
+{% block content %}
+  <div class="grid" style="margin-bottom: 2rem;">
+    <div class="card" style="grid-column: 1 / -1;">
+      <h2>Lieferantenübersicht</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Kontakt</th>
+            <th>Bewertung</th>
+            <th>Materialien</th>
+            <th>Fähigkeiten</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for supplier in suppliers %}
+            <tr>
+              <td>
+                <strong>{{ supplier.name }}</strong><br />
+                <span class="muted">{{ supplier.address }}</span>
+              </td>
+              <td>
+                {{ supplier.contact_person }}<br />
+                <span class="muted">{{ supplier.contact_email }}{% if supplier.contact_phone %} · {{ supplier.contact_phone }}{% endif %}</span>
+              </td>
+              <td>
+                {{ "%.2f"|format(supplier.rating) }} Punkte<br />
+                <span class="muted">{{ supplier.rating_count }} Bewertung(en)</span>
+              </td>
+              <td>
+                {% for item_id in supplier.material_item_ids %}
+                  {% set item = inventory | selectattr("id", "equalto", item_id) | first %}
+                  <span class="tag">{{ item.name if item else item_id }}</span>
+                {% else %}
+                  <span class="muted">Keine Zuordnung</span>
+                {% endfor %}
+              </td>
+              <td>
+                {% for process in supplier.process_capabilities %}
+                  <span class="tag">{{ process.value }}</span>
+                {% else %}
+                  <span class="muted">keine Angaben</span>
+                {% endfor %}
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5" class="muted">Noch keine Lieferanten angelegt.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="grid" style="margin-bottom: 2rem;">
+    <div class="card">
+      <h2>Neuen Lieferanten anlegen</h2>
+      <form method="post" action="/suppliers">
+        <div class="form-grid">
+          <div>
+            <label for="name">Name</label>
+            <input id="name" name="name" required />
+          </div>
+          <div>
+            <label for="address">Adresse</label>
+            <input id="address" name="address" required />
+          </div>
+          <div>
+            <label for="contact_person">Ansprechpartner</label>
+            <input id="contact_person" name="contact_person" />
+          </div>
+          <div>
+            <label for="contact_email">E-Mail</label>
+            <input id="contact_email" name="contact_email" type="email" />
+          </div>
+          <div>
+            <label for="contact_phone">Telefon</label>
+            <input id="contact_phone" name="contact_phone" />
+          </div>
+        </div>
+        <label for="process_capabilities">Fertigungsverfahren (Komma getrennt, z. B. Drehen, Fräsen)</label>
+        <input id="process_capabilities" name="process_capabilities" />
+        <label for="material_item_ids">Material-IDs (Komma getrennt)</label>
+        <input id="material_item_ids" name="material_item_ids" placeholder="{{ inventory | map(attribute='id') | list | join(', ') }}" />
+        <div style="margin-top: 1rem;">
+          <button type="submit">Speichern</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Lieferanten bewerten</h2>
+      <form method="post" action="{% if default_supplier_id %}/suppliers/{{ default_supplier_id }}/evaluation{% else %}#{% endif %}">
+        <label for="supplier_select">Lieferant</label>
+        <select id="supplier_select" name="supplier_id" onchange="this.form.action='/suppliers/'+this.value+'/evaluation'">
+          {% for supplier in suppliers %}
+            <option value="{{ supplier.id }}">{{ supplier.name }}</option>
+          {% endfor %}
+        </select>
+        <div class="form-grid" style="margin-top: 1rem;">
+          <div>
+            <label for="quality_score">Qualität</label>
+            <input id="quality_score" name="quality_score" type="number" min="0" max="5" step="0.1" required />
+          </div>
+          <div>
+            <label for="delivery_reliability_score">Termintreue</label>
+            <input id="delivery_reliability_score" name="delivery_reliability_score" type="number" min="0" max="5" step="0.1" required />
+          </div>
+          <div>
+            <label for="communication_score">Kommunikation</label>
+            <input id="communication_score" name="communication_score" type="number" min="0" max="5" step="0.1" required />
+          </div>
+          <div>
+            <label for="evaluated_on">Bewertungsdatum</label>
+            <input id="evaluated_on" name="evaluated_on" type="date" />
+          </div>
+        </div>
+        <label for="notes">Bemerkungen</label>
+        <textarea id="notes" name="notes"></textarea>
+        <div style="margin-top: 1rem;">
+          <button type="submit">Bewertung speichern</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Material zuordnen</h2>
+      <form method="post" action="{% if default_supplier_id %}/suppliers/{{ default_supplier_id }}/materials{% else %}#{% endif %}">
+        <label for="material_supplier">Lieferant</label>
+        <select id="material_supplier" name="supplier_id" onchange="this.form.action='/suppliers/'+this.value+'/materials'">
+          {% for supplier in suppliers %}
+            <option value="{{ supplier.id }}">{{ supplier.name }}</option>
+          {% endfor %}
+        </select>
+        <label for="item_id">Material</label>
+        <select id="item_id" name="item_id">
+          {% for item in inventory %}
+            <option value="{{ item.id }}">{{ item.name }} ({{ item.id[:8] }})</option>
+          {% endfor %}
+        </select>
+        <div style="margin-top: 1rem;">
+          <button type="submit">Zuordnen</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Bewertungshistorie</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Datum</th>
+          <th>Lieferant</th>
+          <th>Qualität</th>
+          <th>Termintreue</th>
+          <th>Kommunikation</th>
+          <th>Gesamt</th>
+          <th>Notiz</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for evaluation in evaluations %}
+          {% set supplier = suppliers | selectattr("id", "equalto", evaluation.supplier_id) | first %}
+          <tr>
+            <td>{{ evaluation.evaluated_on.strftime("%d.%m.%Y") }}</td>
+            <td>{{ supplier.name if supplier else evaluation.supplier_id }}</td>
+            <td>{{ "%.1f"|format(evaluation.quality_score) }}</td>
+            <td>{{ "%.1f"|format(evaluation.delivery_reliability_score) }}</td>
+            <td>{{ "%.1f"|format(evaluation.communication_score) }}</td>
+            <td>{{ "%.2f"|format(evaluation.overall_score) }}</td>
+            <td>{{ evaluation.notes }}</td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="7" class="muted">Noch keine Bewertungen erfasst.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/erp_system/web/templates/users.html
+++ b/erp_system/web/templates/users.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+
+{% block title %}Benutzerverwaltung{% endblock %}
+
+{% block content %}
+  <div class="card" style="margin-bottom: 1.5rem;">
+    <h2>Benutzer anlegen</h2>
+    <form method="post" action="/users">
+      <div class="form-grid">
+        <div>
+          <label for="user_username">Benutzername</label>
+          <input id="user_username" name="username" required />
+        </div>
+        <div>
+          <label for="user_full_name">Name</label>
+          <input id="user_full_name" name="full_name" />
+        </div>
+        <div>
+          <label for="user_email">E-Mail</label>
+          <input id="user_email" name="email" type="email" />
+        </div>
+        <div>
+          <label>Rollen</label>
+          <div>
+            {% for role in roles %}
+              <label class="checkbox-inline" style="margin-bottom: 0.3rem;">
+                <input type="checkbox" name="roles" value="{{ role.value }}" />
+                <span>{{ role.label }}</span>
+              </label>
+            {% endfor %}
+          </div>
+        </div>
+        <div>
+          <label class="checkbox-inline" style="margin-top: 1.6rem;">
+            <input type="checkbox" name="is_active" checked />
+            <span>Aktiv</span>
+          </label>
+        </div>
+      </div>
+      <div style="margin-top: 1rem;">
+        <button type="submit">Benutzer erstellen</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Bestehende Benutzer</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>E-Mail</th>
+          <th>Rollen</th>
+          <th>Letzte Anmeldung</th>
+          <th>Status</th>
+          <th>Aktionen</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user in users %}
+          <tr>
+            <td><strong>{{ user.full_name or user.username }}</strong><br /><span class="muted">{{ user.username }}</span></td>
+            <td>{{ user.email }}</td>
+            <td>
+              <form method="post" action="/users/{{ user.id }}/roles">
+                {% for role in roles %}
+                  <label class="checkbox-inline" style="margin-bottom: 0.25rem;">
+                    <input type="checkbox" name="roles" value="{{ role.value }}" {% if role in user.roles %}checked{% endif %} />
+                    <span>{{ role.label }}</span>
+                  </label>
+                {% endfor %}
+                <div style="margin-top: 0.5rem;">
+                  <button type="submit" class="secondary">Rollen aktualisieren</button>
+                </div>
+              </form>
+            </td>
+            <td>
+              {% if user.last_login %}
+                {{ user.last_login.strftime('%d.%m.%Y %H:%M') }}
+              {% else %}
+                <span class="muted">noch nicht angemeldet</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if user.is_active %}
+                <span class="status-badge status-RELEASED">Aktiv</span>
+              {% else %}
+                <span class="status-badge status-PLANNED">Inaktiv</span>
+              {% endif %}
+            </td>
+            <td>
+              <form method="post" action="/users/{{ user.id }}/status" class="inline">
+                {% if user.is_active %}
+                  <input type="hidden" name="state" value="inactive" />
+                  <button type="submit" class="secondary">Deaktivieren</button>
+                {% else %}
+                  <input type="hidden" name="state" value="active" />
+                  <button type="submit">Aktivieren</button>
+                {% endif %}
+              </form>
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="6" class="muted">Noch keine Benutzer vorhanden.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.23
+jinja2>=3.1
+python-multipart>=0.0.6


### PR DESCRIPTION
## Summary
- expose configurable planning and procurement options in the service layer to tune scheduling priorities, horizons, buffers and purchasing behaviour
- add dedicated Feinplanung and Einkauf views plus navigation updates so parameter tuning lives on its own pages with dashboard links
- document and demonstrate the new fine-tuning workflow in the README, sample script and package exports
- show machine names in planning-scenario results so the simulation view is easier to read for users

## Testing
- python -m erp_system.sample_usage
- python -m compileall erp_system

------
https://chatgpt.com/codex/tasks/task_e_68d00ca2f924832cac0c61d8ec5809bc